### PR TITLE
Improved zoom behaviour

### DIFF
--- a/main.c
+++ b/main.c
@@ -487,6 +487,8 @@ int main(int argc, char** argv)
   while(!quit) {
     double curTime = SDL_GetTicks() / 1000.0;
     double dt = curTime - lastTime;
+    double prevScale;
+    int x, y;
     lastTime = curTime;
 
     SDL_Event e;
@@ -521,7 +523,27 @@ int main(int argc, char** argv)
           }
           break;
         case SDL_MOUSEWHEEL:
+          SDL_GetMouseState(&x, &y);
+          prevScale = g_view.scale;
           zoom_view(e.wheel.y);
+
+          // Translate mouse coordinates to "projected" coordinates
+          x -= g_view.x;
+          y -= g_view.y;
+
+          double changeX = x - (x * (g_view.scale / prevScale));
+          double changeY = y - (y * (g_view.scale / prevScale));
+
+          if(e.wheel.y < 0 &&
+            (g_view.x <= 0 && (g_view.x + changeX > 0 || !changeX))) {
+              g_view.x = 0;
+          } else g_view.x += changeX;
+
+          if(e.wheel.y < 0 &&
+            (g_view.y <= 0 && (g_view.y + changeY > 0 || !changeY))) {
+              g_view.y = 0;
+          } else g_view.y += changeY;
+
           break;
         case SDL_MOUSEMOTION:
           if(e.motion.state & SDL_BUTTON_LMASK) {


### PR DESCRIPTION
Zooming with the scroll wheel now centres the image on the mouse coordinates, so looking at an area of interest doesn't require zoom+pan.

I left the logic in the main loop, but I can put it in a function if you want.