### PR TITLE
add -n to manpage

### DIFF
--- a/doc/imv.1
+++ b/doc/imv.1
@@ -3,14 +3,14 @@
 imv \- image viewer
 .SH SYNOPSIS
 .nf
-\fBimv\fP [OPTIONS] [IMAGES]
+\fBimv\fP [-irfah] [-n NUM] [images...]
 .fi
 .sp
 .SH DESCRIPTION
 .sp
 \fBimv\fP is a X11/Wayland image viewer aimed at users of tiling window managers.
 It supports a wide variety of image file formats, including animated gif files.
-.SH OPTIONS
+.SH FLAGS
 .TP
 .B -i
 Read paths from stdin. One path per line.
@@ -26,7 +26,11 @@ Default to showing images at actual size.
 .TP
 .B -h
 Print help.
-.SH CONTROLs
+.SH OPTIONS
+.TP
+.BI "-n " NUM
+Start at picture number NUM.
+.SH CONTROLS
 .sp
 imv can be controlled using the mouse or keyboard.
 .TP


### PR DESCRIPTION
I added the -n option, split the OPTIONS into FLAGS and OPTIONS as in the help message and did the same for the usage text.
There are still some inconsistencies however, for example **up** for zoom is listed in manpage but not in help, and **s** is mapped in code but written in neither.