### PR TITLE
Add slideshow option.

### DIFF
--- a/doc/imv.1
+++ b/doc/imv.1
@@ -43,6 +43,10 @@ Set the background color. Either 'checks' or a hex color value.
 .BI "-e " FONT:SIZE
 Set the font used by the overlay. FONT can be any valid system font, such as
 FreeSans, FreeMono, etc. Defaults to FreeMono:24.
+.TP
+.BI "-t " SECONDS
+Set the slideshow delay in seconds. Setting this to zero disables slideshow
+mode, which is the default.
 .SH CONTROLS
 .sp
 imv can be controlled using the mouse or keyboard.
@@ -103,6 +107,13 @@ Step forward one frame (when playing gifs).
 .TP
 .B p
 Print current image path to stdout
+.TP
+.B t
+Increase slideshow delay by one second
+.TP
+.B T
+Decrease slideshow delay by one second. When delay is zero, slideshow mode is
+disabled.
 .SH LEGAL
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Ok, I gave it a go and implemented the slideshow option. Should support all features you requested:

* `-t [time]` option to set how long to show each image for
* `t` key binding increases display time by 1 second
* `T` key binding decreases display time by 1 second
* If non-zero, the time left and display time should be shown in the overlay and window title in the form `[display-time-so-far/display-time]`
* A display time of `0` indicates the slideshow is not active

I wasn't sure how to force a redraw of the image (needed because window title and overlay have to be updated every second for the "countdown"). I don't think settings `view->redraw` directly is the best course of action.

Any suggestions/improvements/requests? Has been some time since I last touched a C codebase, so please don't be too harsh ;)

Resolves #45