### PR TITLE
Fixed linking order to properly link libraries. Linking failed prior

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CFLAGS += -DIMV_VERSION=\"$(VERSION)\"
 
 $(TARGET): $(OBJECTS)
 	@echo "LINKING $@"
-	@$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+	@$(CC) -o $@ $^ $(LDLIBS) $(LDFLAGS)
 
 debug: CFLAGS += -DDEBUG -g -pg
 debug: $(TARGET)


### PR DESCRIPTION
Linking failed due to line 21 of the Makefile as $(LDFLAGS) was set immediately after $(CC).

[First pull request, hope I did this right...]