### PR TITLE
Use default font

### DIFF
--- a/doc/imv.1
+++ b/doc/imv.1
@@ -45,7 +45,8 @@ Set the background color. Either 'checks' or a hex color value. Defaults to '#00
 .TP
 .BI "-e " FONT:SIZE
 Set the font used by the overlay. FONT can be any valid system font, such as
-FreeSans, FreeMono, etc. Defaults to FreeMono:24.
+FreeSans, FreeMono, etc.  Defaults to "Monospace:24", which is default monospace font, as configured in
+.BR fonts.conf (5).
 .TP
 .BI "-t " SECONDS
 Set the slideshow delay in seconds. Setting this to zero disables slideshow

--- a/src/main.c
+++ b/src/main.c
@@ -46,7 +46,7 @@ struct {
   char *overlay_str;
   const char *start_at;
   const char *font;
-} g_options = {0,0,0,0,0,1,0,0,0,0,0,0,NULL,NULL,"FreeMono:24"};
+} g_options = {0,0,0,0,0,1,0,0,0,0,0,0,NULL,NULL,"Monospace:24"};
 
 void print_usage(const char* name)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,7 @@ void print_usage(const char* name)
   "Options:\n"
   "  -n <NUM|PATH>: Start at picture number NUM, or with the path PATH.\n"
   "  -b BG: Set the background. Either 'checks' or a hex color value.\n"
-  "  -e FONT:SIZE: Set the font used for the overlay. Defaults to FreeMono:24\n"
+  "  -e FONT:SIZE: Set the font used for the overlay. Defaults to Monospace:24\n"
   "  -t SECONDS: Enable slideshow mode and set delay between images"
   "\n"
   "Mouse:\n"


### PR DESCRIPTION
"Monospace" is a font name reserved for default monospace font, which is
supposed to be set to particular font user prefers.