### PR TITLE
Build infrastructure improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 
 PREFIX ?= /usr
 
-CFLAGS = -W -Wall -Wpedantic -std=gnu11 `sdl2-config --cflags`
-LDFLAGS = `sdl2-config --libs` -lfreeimage -lSDL2_ttf -lfontconfig -lpthread
+CFLAGS ?= -W -Wall -Wpedantic
+CFLAGS += -std=gnu11 `sdl2-config --cflags`
+LDFLAGS += `sdl2-config --libs` -lfreeimage -lSDL2_ttf -lfontconfig -lpthread
 
 TARGET = imv
 BUILDDIR = build

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ BINPREFIX ?= $(PREFIX)/bin
 MANPREFIX ?= $(PREFIX)/share/man
 DATAPREFIX ?= $(PREFIX)/share
 
-V ?=
+ifeq ($(V),)
+MUTE :=	@
+endif
 
 CFLAGS ?= -W -Wall -Wpedantic
 CFLAGS += -std=gnu11 $(shell sdl2-config --cflags)
@@ -24,26 +26,26 @@ CFLAGS += -DIMV_VERSION=\"$(VERSION)\"
 
 $(TARGET): $(OBJECTS)
 	@echo "LINKING $@"
-	$(V:%=@)$(CC) -o $@ $^ $(LDLIBS) $(LDFLAGS)
+	$(MUTE)$(CC) -o $@ $^ $(LDLIBS) $(LDFLAGS)
 
 debug: CFLAGS += -DDEBUG -g -pg
 debug: $(TARGET)
 
 $(BUILDDIR)/%.o: src/%.c
-	$(V:%=@)mkdir -p $(BUILDDIR)
+	$(MUTE)mkdir -p $(BUILDDIR)
 	@echo "COMPILING $@"
-	$(V:%=@)$(CC) -c $(CFLAGS) -o $@ $<
+	$(MUTE)$(CC) -c $(CFLAGS) -o $@ $<
 
 test_%: test/%.c src/%.c
 	@echo "BUILDING $@"
-	$(V:%=@)$(CC) -o $@ -Isrc -W -Wall -std=gnu11 -lcmocka $^
+	$(MUTE)$(CC) -o $@ -Isrc -W -Wall -std=gnu11 -lcmocka $^
 
 check: $(TESTS)
 	@echo "RUNNING TESTS"
-	$(V:%=@)for t in "$(TESTS)"; do ./$$t; done
+	$(MUTE)for t in "$(TESTS)"; do ./$$t; done
 
 clean:
-	$(V:%=@)$(RM) $(TARGET) $(OBJECTS) $(TESTS)
+	$(MUTE)$(RM) $(TARGET) $(OBJECTS) $(TESTS)
 
 install: $(TARGET)
 	install -D -m 0755 $(TARGET) $(DESTDIR)$(BINPREFIX)/imv

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: clean check install uninstall
 
-prefix = /usr
+PREFIX ?= /usr
 
 CFLAGS = -W -Wall -Wpedantic -std=gnu11 `sdl2-config --cflags`
 LDFLAGS = `sdl2-config --libs` -lfreeimage -lSDL2_ttf -lfontconfig -lpthread
@@ -40,11 +40,11 @@ clean:
 	@$(RM) $(TARGET) $(OBJECTS) $(TESTS)
 
 install: $(TARGET)
-	install -D -m 0755 $(TARGET) $(DESTDIR)$(prefix)/bin/imv
-	install -D -m 0644 doc/imv.1 $(DESTDIR)$(prefix)/share/man/man1/imv.1
-	install -D -m 0644 files/imv.desktop $(DESTDIR)$(prefix)/share/applications/imv.desktop
+	install -D -m 0755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/imv
+	install -D -m 0644 doc/imv.1 $(DESTDIR)$(PREFIX)/share/man/man1/imv.1
+	install -D -m 0644 files/imv.desktop $(DESTDIR)$(PREFIX)/share/applications/imv.desktop
 
 uninstall:
-	$(RM) $(DESTDIR)$(prefix)/bin/imv
-	$(RM) $(DESTDIR)$(prefix)/share/man/man1/imv.1
-	$(RM) $(DESTDIR)$(prefix)/share/applications/imv.desktop
+	$(RM) $(DESTDIR)$(PREFIX)/bin/imv
+	$(RM) $(DESTDIR)$(PREFIX)/share/man/man1/imv.1
+	$(RM) $(DESTDIR)$(PREFIX)/share/applications/imv.desktop

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: clean check install uninstall
 
 PREFIX ?= /usr
+BINPREFIX ?= $(PREFIX)/bin
+MANPREFIX ?= $(PREFIX)/share/man
+DATAPREFIX ?= $(PREFIX)/share
 
 CFLAGS ?= -W -Wall -Wpedantic
 CFLAGS += -std=gnu11 $(shell sdl2-config --cflags)
@@ -41,9 +44,9 @@ clean:
 	@$(RM) $(TARGET) $(OBJECTS) $(TESTS)
 
 install: $(TARGET)
-	install -D -m 0755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/imv
-	install -D -m 0644 doc/imv.1 $(DESTDIR)$(PREFIX)/share/man/man1/imv.1
-	install -D -m 0644 files/imv.desktop $(DESTDIR)$(PREFIX)/share/applications/imv.desktop
+	install -D -m 0755 $(TARGET) $(DESTDIR)$(BINPREFIX)/imv
+	install -D -m 0644 doc/imv.1 $(DESTDIR)$(MANPREFIX)/man1/imv.1
+	install -D -m 0644 files/imv.desktop $(DESTDIR)$(DATAPREFIX)/applications/imv.desktop
 
 uninstall:
 	$(RM) $(DESTDIR)$(PREFIX)/bin/imv

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 PREFIX ?= /usr
 
 CFLAGS ?= -W -Wall -Wpedantic
-CFLAGS += -std=gnu11 `sdl2-config --cflags`
-LDFLAGS += `sdl2-config --libs` -lfreeimage -lSDL2_ttf -lfontconfig -lpthread
+CFLAGS += -std=gnu11 $(shell sdl2-config --cflags)
+LDFLAGS += $(shell sdl2-config --libs) -lfreeimage -lSDL2_ttf -lfontconfig -lpthread
 
 TARGET = imv
 BUILDDIR = build

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ BINPREFIX ?= $(PREFIX)/bin
 MANPREFIX ?= $(PREFIX)/share/man
 DATAPREFIX ?= $(PREFIX)/share
 
+V ?=
+
 CFLAGS ?= -W -Wall -Wpedantic
 CFLAGS += -std=gnu11 $(shell sdl2-config --cflags)
 LDFLAGS += $(shell sdl2-config --libs) -lfreeimage -lSDL2_ttf -lfontconfig -lpthread
@@ -22,26 +24,26 @@ CFLAGS += -DIMV_VERSION=\"$(VERSION)\"
 
 $(TARGET): $(OBJECTS)
 	@echo "LINKING $@"
-	@$(CC) -o $@ $^ $(LDLIBS) $(LDFLAGS)
+	$(V:%=@)$(CC) -o $@ $^ $(LDLIBS) $(LDFLAGS)
 
 debug: CFLAGS += -DDEBUG -g -pg
 debug: $(TARGET)
 
 $(BUILDDIR)/%.o: src/%.c
-	@mkdir -p $(BUILDDIR)
+	$(V:%=@)mkdir -p $(BUILDDIR)
 	@echo "COMPILING $@"
-	@$(CC) -c $(CFLAGS) -o $@ $<
+	$(V:%=@)$(CC) -c $(CFLAGS) -o $@ $<
 
 test_%: test/%.c src/%.c
 	@echo "BUILDING $@"
-	@$(CC) -o $@ -Isrc -W -Wall -std=gnu11 -lcmocka $^
+	$(V:%=@)$(CC) -o $@ -Isrc -W -Wall -std=gnu11 -lcmocka $^
 
 check: $(TESTS)
 	@echo "RUNNING TESTS"
-	@for t in "$(TESTS)"; do ./$$t; done
+	$(V:%=@)for t in "$(TESTS)"; do ./$$t; done
 
 clean:
-	@$(RM) $(TARGET) $(OBJECTS) $(TESTS)
+	$(V:%=@)$(RM) $(TARGET) $(OBJECTS) $(TESTS)
 
 install: $(TARGET)
 	install -D -m 0755 $(TARGET) $(DESTDIR)$(BINPREFIX)/imv

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ available.  Eg. to install `imv` to home directory, run:
 
     $ BINPREFIX=~/bin PREFIX=~/.local make install
 
+In case something goes wrong during installation process you may use verbose
+mode to inspect commands issued by make:
+
+    $ V=1 make
+
 Tests
 -----
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Installation
     $ make
     # make install
 
+Macro `PREFIX` controls installation prefix.  If more control over installation
+paths is required, macros `BINPREFIX`, `MANPREFIX` and `DATAPREFIX` are
+available.  Eg. to install `imv` to home directory, run:
+
+    $ BINPREFIX=~/bin PREFIX=~/.local make install
+
 Tests
 -----
 


### PR DESCRIPTION
* Use `PREFIX` instead of `prefix` (compatibility with various package managers)
* Respect user's `CFLAGS`
* Avoid executing `sdl-config` multiple times
* More configuration options for install paths
* Verbose build mode