### PR TITLE
Drop `obj` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: imv obj clean check install uninstall
+.PHONY: imv clean check install uninstall
 
 PREFIX ?= /usr
 BINPREFIX ?= $(PREFIX)/bin
@@ -26,14 +26,14 @@ CFLAGS += -DIMV_VERSION=\"$(VERSION)\"
 
 imv: $(TARGET)
 
-$(TARGET): obj
+$(TARGET): $(OBJECTS)
 	@echo "LINKING $@"
-	$(MUTE)$(CC) -o $@ $(OBJECTS) $(LDLIBS) $(LDFLAGS)
+	$(MUTE)$(CC) -o $@ $^ $(LDLIBS) $(LDFLAGS)
 
 debug: CFLAGS += -DDEBUG -g -pg
 debug: $(TARGET)
 
-obj: $(BUILDDIR) $(OBJECTS)
+$(OBJECTS): | $(BUILDDIR)
 
 $(BUILDDIR):
 	$(MUTE)mkdir -p $(BUILDDIR)


### PR DESCRIPTION
I introduced it to make object files depend on `$(BUILDDIR)` so that creating it could be moved into separate rule, executed once.  That was a bad idea, because `obj` had to be *phony*, thus making all targets that depend on it obsolete between runs of make.  This change introduces *order-only* rule that makes object files depend on `$(BUILDDIR)` without obsoleting other targets.