### PR TITLE
Hide functions that are not exposed via headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifeq ($(V),)
 MUTE :=	@
 endif
 
-CFLAGS ?= -W -Wall -Wpedantic
+CFLAGS ?= -W -Wall -Wpedantic -Wmissing-prototypes
 CFLAGS += -std=gnu11 $(shell sdl2-config --cflags)
 LDFLAGS += $(shell sdl2-config --libs) -lfreeimage -lSDL2_ttf -lfontconfig -lpthread
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -140,7 +140,7 @@ void imv_loader_time_passed(struct imv_loader *ldr, double dt)
   }
 }
 
-void imv_loader_error_occurred(struct imv_loader *ldr)
+static void imv_loader_error_occurred(struct imv_loader *ldr)
 {
   pthread_mutex_lock(&ldr->lock);
   if(ldr->out_err) {

--- a/src/main.c
+++ b/src/main.c
@@ -63,7 +63,7 @@ struct {
   .font = "Monospace:24",
 };
 
-void print_usage(const char* name)
+static void print_usage(const char* name)
 {
   fprintf(stdout,
   "imv %s\n"
@@ -123,7 +123,7 @@ void print_usage(const char* name)
   , IMV_VERSION, name);
 }
 
-void parse_args(int argc, char** argv)
+static void parse_args(int argc, char** argv)
 {
   /* Do not print getopt errors */
   opterr = 0;


### PR DESCRIPTION
As detected with `-Wmissing-prototypes`.