### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+dist: trusty
+
+language: c
+
+compiler:
+  - clang
+  - gcc
+
+env:
+  - V=yes
+
+script:
+  - make
+# - make check
+
+notifications:
+  email: false
+
+addons:
+  apt:
+    packages:
+      - libfreeimage-dev
+      - libsdl2-ttf-dev
+#     - libcmocka-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ compiler:
   - gcc
 
 env:
-  - V=yes
+  - V=yes CFLAGS="-W -Wall -Wextra -Wpedantic -Wpointer-arith -Wuninitialized -Wstrict-prototypes -Wmissing-prototypes -Wunused -Wsign-compare -Wshadow -Werror"
 
 script:
   - make

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/czarkoff/imv.svg?branch=master)](https://travis-ci.org/czarkoff/imv)
 imv - X11/Wayland Image Viewer
 ==============================
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/czarkoff/imv.svg?branch=master)](https://travis-ci.org/czarkoff/imv)
+[![Build Status](https://travis-ci.org/eXeC64/imv.svg?branch=master)](https://travis-ci.org/eXeC64/imv)
 imv - X11/Wayland Image Viewer
 ==============================
 


### PR DESCRIPTION
Unfortunately, Travis only wants to use Ubuntu LTS releases, so at least until
next Ubuntu LTS release we are stuck with ancient cmocka version.  So no
automated testing yet.

Don't forget to toggle this repo on in your Travis Github account.