### PR TITLE
Loading image data from standard input

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,16 @@ Usage
     imv image1.png another_image.jpeg yet_another.TIFF
 
 ### Opening images via stdin
-    find . "*.png" | imv -
+    find . "*.png" | imv
 
 ### Open an image fullscreen
     imv -f image.jpeg
 
 ### Viewing images in a random order
-    find . "*.png" | shuf | imv -
+    find . "*.png" | shuf | imv
+
+### Viewing images from stdin
+    curl http://somesi.te/img.png | imv -
 
 ### Image picker
 imv can be used to select images in a pipeline by using the `p` hotkey to print
@@ -35,13 +38,13 @@ to list the remaining paths on exit for a "open set of images, close unwanted
 ones with `x`, then quit imv to pass the remaining images through" workflow.
 
 #### Picking a wallpaper
-    custom-set-wallpaper-script "$(find ./wallpaper -type f -name '*.jpg' | imv - | tail -n1)"
+    custom-set-wallpaper-script "$(find ./wallpaper -type f -name '*.jpg' | imv | tail -n1)"
 
 #### Deleting unwanted images
-    find -type f -name '*.jpg' | imv - | xargs rm -v
+    find -type f -name '*.jpg' | imv | xargs rm -v
 
 #### Choosing pictures to email
-    find ./holiday_pics -type f -name '*.jpg' | imv - | xargs cp -t ~/outbox
+    find ./holiday_pics -type f -name '*.jpg' | imv | xargs cp -t ~/outbox
 
 ### Slideshow
 

--- a/doc/imv.1
+++ b/doc/imv.1
@@ -21,12 +21,8 @@ It supports a wide variety of image file formats, including animated gif files.
 .Nm
 reloads the current image if it detects changes to the file.
 .Pp
-When run with argument
-.Sq - ,
 .Nm
-reads the list of images from standard input.
-.Pp
-The options are as follows:
+accepts following flags:
 .Bl -tag -width Ds
 .It Fl a
 Default to showing images at actual size.
@@ -66,6 +62,17 @@ Setting this to zero disables slideshow mode, which is the default.
 .It Fl u
 Use nearest neighbour resampling. Recommended for pixel art.
 .El
+.Ss Reading from standard input
+When run with argument
+.Sq - ,
+.Nm
+reads image from standard input.
+Argument
+.Sq -
+may occur among other arguments, but only once.
+.Pp
+If no arguments supplied, reads list of files from standard input.
+.Pp
 .Sh CONTROLS
 .Bl -tag -width Ds
 .It Aq Cm left mouse button
@@ -111,6 +118,13 @@ Increase slideshow delay by one second
 .It Cm T
 Decrease slideshow delay by one second.
 When delay is zero, slideshow mode is disabled.
+.Sh EXAMPLES
+Load all files from directory
+.Pa dir :
+.Pp
+.Dl $ ls dir | imv
+or
+.Dl $ ls dir | xargs imv
 .Sh LEGAL
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/src/loader.c
+++ b/src/loader.c
@@ -143,16 +143,6 @@ void imv_loader_time_passed(struct imv_loader *ldr, double dt)
   }
 }
 
-static void error_occurred(struct imv_loader *ldr)
-{
-  pthread_mutex_lock(&ldr->lock);
-  if(ldr->out_err) {
-    free(ldr->out_err);
-  }
-  ldr->out_err = strdup(ldr->path);
-  pthread_mutex_unlock(&ldr->lock);
-}
-
 static void *bg_new_img(void *data)
 {
   /* so we can poll for it */
@@ -375,4 +365,14 @@ static void *bg_next_frame(void *data)
 
   pthread_mutex_unlock(&ldr->lock);
   return NULL;
+}
+
+static void error_occurred(struct imv_loader *ldr)
+{
+  pthread_mutex_lock(&ldr->lock);
+  if(ldr->out_err) {
+    free(ldr->out_err);
+  }
+  ldr->out_err = strdup(ldr->path);
+  pthread_mutex_unlock(&ldr->lock);
 }

--- a/src/loader.c
+++ b/src/loader.c
@@ -21,6 +21,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <pthread.h>
 #include <signal.h>
 
+static void block_usr1_signal(void);
+static int is_thread_cancelled(void);
+static void *bg_new_img(void *data);
+static void *bg_next_frame(void *data);
+static void error_occurred(struct imv_loader *ldr);
+
 static void block_usr1_signal(void)
 {
   sigset_t sigmask;
@@ -60,9 +66,6 @@ void imv_destroy_loader(struct imv_loader *ldr)
     free(ldr->path);
   }
 }
-
-static void *bg_new_img(void *data);
-static void *bg_next_frame(void *data);
 
 void imv_loader_load_path(struct imv_loader *ldr, const char *path)
 {

--- a/src/loader.c
+++ b/src/loader.c
@@ -17,6 +17,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include "loader.h"
 #include "texture.h"
+#include <limits.h>
 #include <stdlib.h>
 #include <pthread.h>
 #include <signal.h>
@@ -67,7 +68,8 @@ void imv_destroy_loader(struct imv_loader *ldr)
   }
 }
 
-void imv_loader_load_path(struct imv_loader *ldr, const char *path)
+void imv_loader_load(struct imv_loader *ldr, const char *path,
+                     const void *buffer, const size_t buffer_size)
 {
   /* cancel existing thread if already running */
   if(ldr->bg_thread) {
@@ -80,6 +82,12 @@ void imv_loader_load_path(struct imv_loader *ldr, const char *path)
     free(ldr->path);
   }
   ldr->path = strdup(path);
+  if (strncmp(path, "-", 2) == 0) {
+    ldr->buffer = (BYTE *)buffer;
+    ldr->buffer_size = buffer_size;
+  } else if (ldr->fi_buffer != NULL) {
+    FreeImage_CloseMemory(ldr->fi_buffer);
+  }
   pthread_create(&ldr->bg_thread, NULL, &bg_new_img, ldr);
   pthread_mutex_unlock(&ldr->lock);
 }
@@ -149,16 +157,31 @@ static void *bg_new_img(void *data)
   block_usr1_signal();
 
   struct imv_loader *ldr = data;
+  char path[PATH_MAX] = "-";
 
   pthread_mutex_lock(&ldr->lock);
-  char *path = strdup(ldr->path);
+  int from_stdin = !strncmp(path, ldr->path, 2);
+  if(!from_stdin) {
+    (void)snprintf(path, PATH_MAX, "%s", ldr->path);
+  }
   pthread_mutex_unlock(&ldr->lock);
 
-  FREE_IMAGE_FORMAT fmt = FreeImage_GetFileType(path, 0);
-
+  FREE_IMAGE_FORMAT fmt;
+  if (from_stdin) {
+    pthread_mutex_lock(&ldr->lock);
+    ldr->fi_buffer = FreeImage_OpenMemory(ldr->buffer, ldr->buffer_size);
+    fmt = FreeImage_GetFileTypeFromMemory(ldr->fi_buffer, 0);
+    pthread_mutex_unlock(&ldr->lock);
+  } else {
+    fmt = FreeImage_GetFileType(path, 0);
+  }
   if(fmt == FIF_UNKNOWN) {
+    if (from_stdin) {
+      pthread_mutex_lock(&ldr->lock);
+      FreeImage_CloseMemory(ldr->fi_buffer);
+      pthread_mutex_unlock(&ldr->lock);
+    }
     error_occurred(ldr);
-    free(path);
     return NULL;
   }
 
@@ -169,12 +192,18 @@ static void *bg_new_img(void *data)
   int raw_frame_time = 100; /* default to 100 */
 
   if(fmt == FIF_GIF) {
-    mbmp = FreeImage_OpenMultiBitmap(FIF_GIF, path,
+    if(from_stdin) {
+      pthread_mutex_lock(&ldr->lock);
+      mbmp = FreeImage_LoadMultiBitmapFromMemory(FIF_GIF, ldr->fi_buffer,
+          GIF_LOAD256);
+      pthread_mutex_unlock(&ldr->lock);
+    } else {
+      mbmp = FreeImage_OpenMultiBitmap(FIF_GIF, path,
       /* don't create file */ 0,
       /* read only */ 1,
       /* keep in memory */ 1,
       /* flags */ GIF_LOAD256);
-    free(path);
+    }
     if(!mbmp) {
       error_occurred(ldr);
       return NULL;
@@ -198,10 +227,20 @@ static void *bg_new_img(void *data)
   } else {
     /* Future TODO: If we load image line-by-line we could stop loading large
      * ones before wasting much more time/memory on them. */
-    FIBITMAP *image = FreeImage_Load(fmt, path, 0);
-    free(path);
+    FIBITMAP *image;
+    if(from_stdin) {
+      pthread_mutex_lock(&ldr->lock);
+      image = FreeImage_LoadFromMemory(fmt, ldr->fi_buffer, 0);
+      pthread_mutex_unlock(&ldr->lock);
+    } else {
+      image = FreeImage_Load(fmt, path, 0);
+    }
     if(!image) {
       error_occurred(ldr);
+      pthread_mutex_lock(&ldr->lock);
+      FreeImage_CloseMemory(ldr->fi_buffer);
+      ldr->fi_buffer = NULL;
+      pthread_mutex_unlock(&ldr->lock);
       return NULL;
     }
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -166,7 +166,7 @@ static void *imv_loader_bg_new_img(void *data)
   if(fmt == FIF_UNKNOWN) {
     imv_loader_error_occurred(ldr);
     free(path);
-    return 0;
+    return NULL;
   }
 
   int num_frames = 1;
@@ -184,7 +184,7 @@ static void *imv_loader_bg_new_img(void *data)
     free(path);
     if(!mbmp) {
       imv_loader_error_occurred(ldr);
-      return 0;
+      return NULL;
     }
 
     num_frames = FreeImage_GetPageCount(mbmp);
@@ -209,13 +209,13 @@ static void *imv_loader_bg_new_img(void *data)
     free(path);
     if(!image) {
       imv_loader_error_occurred(ldr);
-      return 0;
+      return NULL;
     }
 
     /* Check for cancellation before we convert pixel format */
     if(is_thread_cancelled()) {
       FreeImage_Unload(image);
-      return 0;
+      return NULL;
     }
 
     width = FreeImage_GetWidth(bmp);
@@ -236,7 +236,7 @@ static void *imv_loader_bg_new_img(void *data)
       FreeImage_Unload(bmp);
     }
     pthread_mutex_unlock(&ldr->lock);
-    return 0;
+    return NULL;
   }
 
   if(ldr->mbmp) {
@@ -262,7 +262,7 @@ static void *imv_loader_bg_new_img(void *data)
   ldr->frame_time = (double)raw_frame_time * 0.0001;
 
   pthread_mutex_unlock(&ldr->lock);
-  return 0;
+  return NULL;
 }
 
 static void *imv_loader_bg_next_frame(void *data)
@@ -273,7 +273,7 @@ static void *imv_loader_bg_next_frame(void *data)
   int num_frames = ldr->num_frames;
   if(num_frames < 2) {
     pthread_mutex_unlock(&ldr->lock);
-    return 0;
+    return NULL;
   }
 
   FITAG *tag = NULL;
@@ -371,5 +371,5 @@ static void *imv_loader_bg_next_frame(void *data)
   ldr->out_is_new_image = 0;
 
   pthread_mutex_unlock(&ldr->lock);
-  return 0;
+  return NULL;
 }

--- a/src/loader.h
+++ b/src/loader.h
@@ -28,6 +28,9 @@ struct imv_loader {
   pthread_mutex_t lock;
   pthread_t bg_thread;
   char *path;
+  BYTE *buffer;
+  size_t buffer_size;
+  FIMEMORY *fi_buffer;
   FIBITMAP *out_bmp;
   int out_is_new_image;
   char *out_err;
@@ -48,7 +51,8 @@ void imv_init_loader(struct imv_loader *img);
 void imv_destroy_loader(struct imv_loader *img);
 
 /* Asynchronously load the given file */
-void imv_loader_load_path(struct imv_loader *ldr, const char *path);
+void imv_loader_load(struct imv_loader *ldr, const char *path,
+                     const void *buffer, const size_t buffer_size);
 
 /* Returns 1 if image data is available. 0 if not. Caller is responsible for
  * cleaning up the data returned. Each image is only returned once.

--- a/src/main.c
+++ b/src/main.c
@@ -217,7 +217,7 @@ int main(int argc, char** argv)
 
   /* if the user asked us to load paths from stdin, now is the time */
   if(g_options.sin) {
-    char buf[512];
+    char buf[PATH_MAX];
     while(fgets(buf, sizeof(buf), stdin)) {
       size_t len = strlen(buf);
       if(buf[len-1] == '\n') {

--- a/src/navigator.c
+++ b/src/navigator.c
@@ -17,6 +17,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include "navigator.h"
 
+#include <limits.h>
 #include <sys/stat.h>
 #include <dirent.h>
 #include <stdlib.h>
@@ -84,7 +85,7 @@ static void add_item(struct imv_navigator *nav, const char *path,
 void imv_navigator_add(struct imv_navigator *nav, const char *path,
                        int recursive)
 {
-  char path_buf[512];
+  char path_buf[PATH_MAX];
   struct stat path_info;
   stat(path, &path_info);
   if(S_ISDIR(path_info.st_mode)) {

--- a/src/util.h
+++ b/src/util.h
@@ -21,6 +21,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
 
+/* Read binary data from stdin into buffer */
+size_t read_from_stdin(void **buffer);
+
 /* Creates a new SDL_Texture* containing a chequeboard texture */
 SDL_Texture *create_chequered(SDL_Renderer *renderer);
 


### PR DESCRIPTION
This pull request is loosely based on #48, but it also changes processing of arguments:

* When called without arguments (with or without flags), imv reads list of files from standard input.
* When called with `-` among arguments, imv reads image data from standard input. Works for both still and animated images.

There is also a handful of more or less unrelated changes: small issues I've found and fixes while figuring out the proper way to get things done.