### PR TITLE
Add third scaling mode: best fit

### DIFF
--- a/doc/imv.1
+++ b/doc/imv.1
@@ -6,7 +6,7 @@
 .Nd view images
 .Sh SYNOPSIS
 .Nm
-.Op Fl adfhlru
+.Op Fl adfhlrSsu
 .Op Fl b Ar color
 .Op Fl e Ar font:size
 .Op Fl n Ar position
@@ -25,7 +25,8 @@ reloads the current image if it detects changes to the file.
 accepts following flags:
 .Bl -tag -width Ds
 .It Fl a
-Default to showing images at actual size.
+.Dq actual size
+mode: show images at actual size.
 .It Fl b Ar color
 Set the background color.
 Either
@@ -55,12 +56,21 @@ Start at specific position in image list.
 may be expressed as a number or as a path of an image.
 .It Fl r
 Recursively search input paths for files.
+.It Fl S
+.Dq perfect fit 
+mode: upscale or downscale image to fit window.
+This is the default.
+.It Fl s
+.Dq best fit
+mode: downscale image to fit window.
+Images that are smaller then window are shown in actual size.
 .It Fl t Ar seconds 
 Set the slideshow delay in seconds.
 Fractional numbers are accepted.
 Setting this to zero disables slideshow mode, which is the default.
 .It Fl u
-Use nearest neighbour resampling. Recommended for pixel art.
+Use nearest neighbour resampling.
+Recommended for pixel art.
 .El
 .Ss Reading from standard input
 When run with argument
@@ -113,6 +123,17 @@ Toggle gif playback.
 Step forward one frame (when playing gifs).
 .It Cm p
 Print current image path to stdout
+.It Cm s
+Switch scaling mode.
+Available modes are:
+.Dq actual size
+.Pq don't scale images ,
+.Dq best fit
+.Pq downscale images to fit window, but don't scale smaller images ,
+.Dq perfect fit
+.Pq upscale or downscale images to fit window
+.Pq default ,
+in this order.
 .It Cm t
 Increase slideshow delay by one second
 .It Cm T


### PR DESCRIPTION
Although I've seen your recommendation in #77, I decided to present different approach.

* Add new switches: `-S` to force (default) "perfect fit" mode and `-s` to force "best fit" mode.
* Add new control key: `s` to switch scaling mode.

So far user don't really need to specify `-S` unless overrides default in some script. Thus scaling modes are basically controlled via switches `-a` (mnemonic: *a*ctual) and `-s` (mnemonic: *s*cale). In my opinion, it is easier to remember and less irritating to type then `-m best`.

Note, key `a` zooms to actual size without changing mode.