### PR TITLE
Read file list from standard input continuosly

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ones with `x`, then quit imv to pass the remaining images through" workflow.
     find ./holiday_pics -type f -name '*.jpg' | imv | xargs cp -t ~/outbox
 
 #### Viewing images from the web
-    curl -Osw '%{filename_effective}\n' 'http://www.example.com/[1-10].jpg'
+    curl -Osw '%{filename_effective}\n' 'http://www.example.com/[1-10].jpg' | imv
 
 ### Slideshow
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ ones with `x`, then quit imv to pass the remaining images through" workflow.
 #### Choosing pictures to email
     find ./holiday_pics -type f -name '*.jpg' | imv | xargs cp -t ~/outbox
 
+#### Viewing images from the web
+    curl -Osw '%{filename_effective}\n' 'http://www.example.com/[1-10].jpg'
+
 ### Slideshow
 
 imv can be used to display slideshows. You can set the number of seconds to


### PR DESCRIPTION
This reduces delay before initial draw in case of slow input, opening possibilities for use cases like:
```shell
$ curl -Osw "%{filename_effective}\n" "http://www.example.com/[1-10].jpg" | imv
```
which will download all images and start showing them once first arrives.

Fixes #58, sort of.