### PR TITLE
Add -x switch to exit imv when reaching end of file list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ To cycle through a folder of pictures, showing each one for 10 seconds:
 
     imv -t 10 ~/Pictures/London
 
+The `-x` switch can be used to exit imv after the last picture instead of
+cycling through the list.
+
 Installation
 ------------
 

--- a/doc/imv.1
+++ b/doc/imv.1
@@ -6,7 +6,7 @@
 .Nd view images
 .Sh SYNOPSIS
 .Nm
-.Op Fl adfhlrSsu
+.Op Fl adfhlrSsux
 .Op Fl b Ar color
 .Op Fl e Ar font:size
 .Op Fl n Ar position
@@ -71,6 +71,8 @@ Setting this to zero disables slideshow mode, which is the default.
 .It Fl u
 Use nearest neighbour resampling.
 Recommended for pixel art.
+.It Fl x
+Exit when reaching end of file list.
 .El
 .Ss Reading from standard input
 When run with argument

--- a/src/main.c
+++ b/src/main.c
@@ -55,6 +55,7 @@ struct {
   int solid_bg;
   int list;
   unsigned long delay;
+  int cycle;
   unsigned char bg_r;
   unsigned char bg_g;
   unsigned char bg_b;
@@ -71,6 +72,7 @@ struct {
   .solid_bg = 1,
   .list = 0,
   .delay = 0,
+  .cycle = 1,
   .bg_r = 0,
   .bg_g = 0,
   .bg_b = 0,
@@ -105,7 +107,7 @@ static void parse_args(int argc, char** argv)
 
   char *argp, o;
 
-  while((o = getopt(argc, argv, "firasSudhln:b:e:t:")) != -1) {
+  while((o = getopt(argc, argv, "firasSudxhln:b:e:t:")) != -1) {
     switch(o) {
       case 'f': g_options.fullscreen = 1;   break;
       case 'i':
@@ -118,6 +120,7 @@ static void parse_args(int argc, char** argv)
       case 'S': g_options.scaling = FULL;          break;
       case 'u': g_options.nearest_neighbour = 1;   break;
       case 'd': g_options.overlay = 1;             break;
+      case 'x': g_options.cycle = 0;               break;
       case 'h': print_usage(); exit(0);            break;
       case 'l': g_options.list = 1;                break;
       case 'n':
@@ -345,13 +348,17 @@ int main(int argc, char** argv)
               break;
             case SDLK_LEFTBRACKET:
             case SDLK_LEFT:
-              imv_navigator_select_rel(&nav, -1);
+              if(!imv_navigator_select_rel(&nav, -1, g_options.cycle)) {
+                quit = 1;
+              }
               /* reset slideshow delay */
               delay_msec = 0;
               break;
             case SDLK_RIGHTBRACKET:
             case SDLK_RIGHT:
-              imv_navigator_select_rel(&nav, 1);
+              if(!imv_navigator_select_rel(&nav, 1, g_options.cycle)) {
+                quit = 1;
+              }
               /* reset slideshow delay */
               delay_msec = 0;
               break;
@@ -523,7 +530,9 @@ int main(int argc, char** argv)
       delay_msec += dt;
       need_redraw = 1;
       if(delay_msec >= g_options.delay) {
-        imv_navigator_select_rel(&nav, 1);
+        if(!imv_navigator_select_rel(&nav, 1, g_options.cycle)) {
+          quit = 1;
+        }
         delay_msec = 0;
       }
     }

--- a/src/navigator.h
+++ b/src/navigator.h
@@ -47,8 +47,11 @@ void imv_navigator_add(struct imv_navigator *nav, const char *path,
  * guaranteed to be valid until the next call to an imv_navigator method. */
 const char *imv_navigator_selection(struct imv_navigator *nav);
 
-/* Change the currently selected path. dir = -1 for previous, 1 for next */
-void imv_navigator_select_rel(struct imv_navigator *nav, int dir);
+/* Change the currently selected path. dir = -1 for previous, 1 for next
+ * cycle = 1 to go to the beginning of the file list if end is reached
+ * cycle = 0 to return error instead
+ * Returns 1 on success, 0 otherwise */
+int imv_navigator_select_rel(struct imv_navigator *nav, int dir, int cycle);
 
 /* Removes the given path. The current selection is updated if necessary,
  * based on the last direction the selection moved. */


### PR DESCRIPTION
So I implemented the option dicussed in #84.

I chose `-x` for the switch (for eXit), because `-q` is commonly used to suppress output and `-o` is somewhat non-obvious.

I'm not really sure whether the change to the signature of `imv_navigator_select_rel()` is a good idea, but it looked like the easiest and cleanest way to do it this way for me.

All tests pass.

Closes #84 