### PR TITLE
Make '+' work on all layouts

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -363,6 +363,7 @@ int main(int argc, char** argv)
               delay_msec = 0;
               break;
             case SDLK_EQUALS:
+            case SDLK_PLUS:
             case SDLK_i:
             case SDLK_UP:
               imv_viewport_zoom(&view, &tex, IMV_ZOOM_KEYBOARD, 1);


### PR DESCRIPTION
Key handling code obuses the fact that plus sign is shifted key for equals sign
on US keyboard.  Add '+' as a control for layouts where this is not the case.

Fixes #88. @rumpelsepp, please test.