### PR TITLE
Gif slideshow

### DIFF
--- a/doc/imv.1
+++ b/doc/imv.1
@@ -6,7 +6,7 @@
 .Nd view images
 .Sh SYNOPSIS
 .Nm
-.Op Fl adfhlrSsux
+.Op Fl 1adfhlrSsux
 .Op Fl b Ar color
 .Op Fl e Ar font:size
 .Op Fl n Ar position
@@ -24,6 +24,10 @@ reloads the current image if it detects changes to the file.
 .Nm
 accepts following flags:
 .Bl -tag -width Ds
+.It Fl 1
+Play animations only once.
+Pauses animation at last frame.
+If user resumes playback, animation would pause again at its last frame.
 .It Fl a
 .Dq actual size
 mode: show images at actual size.

--- a/src/loader.c
+++ b/src/loader.c
@@ -93,7 +93,7 @@ void imv_loader_load(struct imv_loader *ldr, const char *path,
 }
 
 int imv_loader_get_image(struct imv_loader *ldr, FIBITMAP **out_bmp,
-                         int *out_is_new_image)
+                         int *frame_number, int *num_frames)
 {
   int ret = 0;
   pthread_mutex_lock(&ldr->lock);
@@ -101,8 +101,11 @@ int imv_loader_get_image(struct imv_loader *ldr, FIBITMAP **out_bmp,
   if(ldr->out_bmp) {
     *out_bmp = ldr->out_bmp;
     ldr->out_bmp = NULL;
-    *out_is_new_image = ldr->out_is_new_image;
-    ldr->out_is_new_image = 0;
+    *frame_number = ldr->frame_number++;
+    *num_frames = ldr->num_frames;
+    if (ldr->frame_number == ldr->num_frames) {
+      ldr->frame_number = 0;
+    }
     ret = 1;
   }
 
@@ -288,7 +291,7 @@ static void *bg_new_img(void *data)
     FreeImage_Unload(ldr->out_bmp);
   }
   ldr->out_bmp = FreeImage_Clone(bmp);
-  ldr->out_is_new_image = 1;
+  ldr->frame_number = 0;
   ldr->width = width;
   ldr->height = height;
   ldr->cur_frame = 0;

--- a/src/loader.h
+++ b/src/loader.h
@@ -32,7 +32,7 @@ struct imv_loader {
   size_t buffer_size;
   FIMEMORY *fi_buffer;
   FIBITMAP *out_bmp;
-  int out_is_new_image;
+  int frame_number;
   char *out_err;
   FIMULTIBITMAP *mbmp;
   FIBITMAP *bmp;
@@ -56,10 +56,10 @@ void imv_loader_load(struct imv_loader *ldr, const char *path,
 
 /* Returns 1 if image data is available. 0 if not. Caller is responsible for
  * cleaning up the data returned. Each image is only returned once.
- * out_is_frame indicates whether the returned image is a new image, or just
- * a new frame of an existing one. */
+ * frame_number and num_frames report number of current frame and total amount
+ * of frames in image. */
 int imv_loader_get_image(struct imv_loader *ldr, FIBITMAP **out_bmp,
-                         int *out_is_frame);
+                         int *frame_number, int *num_frames);
 
 /* If a file failed to load, return the path to that file. Otherwise returns
  * NULL. Only returns the path once. Caller is responsible for cleaning up the

--- a/src/main.c
+++ b/src/main.c
@@ -527,6 +527,7 @@ int main(int argc, char** argv)
       if(g_options.delay && g_options.play_once && frame_number == 0 &&
           num_frames > 1 && repeated) {
         imv_navigator_select_rel(&nav, 1);
+        delay_msec = 0;
         continue;
       }
       imv_texture_set_image(&tex, bmp);

--- a/src/main.c
+++ b/src/main.c
@@ -316,7 +316,7 @@ int main(int argc, char** argv)
   }
 
   /* help keeping track of time */
-  unsigned int last_time;
+  unsigned int last_time = SDL_GetTicks();
   unsigned int current_time;
 
   /* keep file change polling rate under control */
@@ -525,7 +525,7 @@ int main(int argc, char** argv)
     int frame_number, num_frames;
     if(imv_loader_get_image(&ldr, &bmp, &frame_number, &num_frames)) {
       if(g_options.delay && g_options.play_once && frame_number == 0 &&
-          repeated) {
+          num_frames > 1 && repeated) {
         imv_navigator_select_rel(&nav, 1);
         continue;
       }
@@ -539,7 +539,7 @@ int main(int argc, char** argv)
       }
       if(frame_number == num_frames - 1) {
         repeated = 1;
-        } if(g_options.play_once) {
+        if(g_options.play_once && !g_options.delay) {
           imv_viewport_toggle_playing(&view);
         }
       }
@@ -565,7 +565,7 @@ int main(int argc, char** argv)
     }
 
     /* handle slideshow */
-    if(g_options.delay && !(g_options.play_once && num_frames > 1)) {
+    if(g_options.delay) {
       unsigned int dt = current_time - last_time;
 
       delay_msec += dt;
@@ -593,7 +593,8 @@ int main(int argc, char** argv)
       if(num_frames > 1) {
         snprintf(title, sizeof(title), "%s [%i/%i]", title, frame_number + 1,
             num_frames);
-      } else if(g_options.delay >= 1000) {
+      }
+      if(g_options.delay >= 1000) {
         snprintf(title, sizeof(title), "%s [%lu/%lus]", title,
             delay_msec / 1000 + 1, g_options.delay / 1000);
       }

--- a/src/main.c
+++ b/src/main.c
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "viewport.h"
 #include "util.h"
 
-enum scaling_mode {
+enum scaling_modes {
   NONE,
   DOWN,
   FULL
@@ -55,6 +55,7 @@ struct {
   int solid_bg;
   int list;
   unsigned long delay;
+  int play_once;
   int cycle;
   unsigned char bg_r;
   unsigned char bg_g;
@@ -71,6 +72,7 @@ struct {
   .solid_bg = 1,
   .list = 0,
   .delay = 0,
+  .play_once = 0,
   .cycle = 1,
   .bg_r = 0,
   .bg_g = 0,
@@ -105,9 +107,10 @@ static void parse_args(int argc, char** argv)
 
   char *argp, o;
 
-  while((o = getopt(argc, argv, "firasSudxhln:b:e:t:")) != -1) {
+  while((o = getopt(argc, argv, "1firasSudxhln:b:e:t:")) != -1) {
     switch(o) {
-      case 'f': g_options.fullscreen = 1;   break;
+      case '1': g_options.play_once = 1;           break;
+      case 'f': g_options.fullscreen = 1;          break;
       case 'i':
         g_options.stdin_list = 1;
         fprintf(stderr, "Warning: '-i' is deprecated. No flag is needed.\n");
@@ -523,6 +526,9 @@ int main(int argc, char** argv)
       need_redraw = 1;
       if(frame_number == 0) {
         need_rescale = 1;
+      }
+      if(g_options.play_once && frame_number == num_frames - 1) {
+        imv_viewport_toggle_playing(&view);
       }
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -586,16 +586,17 @@ int main(int argc, char** argv)
     /* only redraw when something's changed */
     if(need_redraw) {
       /* update window title */
+      int len;
       const char *current_path = imv_navigator_selection(&nav);
-      snprintf(title, sizeof(title), "imv - [%i/%i] [%ix%i] %s [%s]",
+      len = snprintf(title, sizeof(title), "imv - [%i/%i] [%ix%i] %s [%s]",
           nav.cur_path + 1, nav.num_paths, tex.width, tex.height,
           current_path, scaling_label[g_options.scaling]);
       if(num_frames > 1) {
-        snprintf(title, sizeof(title), "%s [%i/%i]", title, frame_number + 1,
-            num_frames);
+        len += snprintf(title + len, sizeof(title) - len, " [%i/%i]",
+            frame_number + 1, num_frames);
       }
       if(g_options.delay >= 1000) {
-        snprintf(title, sizeof(title), "%s [%lu/%lus]", title,
+        len += snprintf(title + len, sizeof(title) - len, " [%lu/%lus]",
             delay_msec / 1000 + 1, g_options.delay / 1000);
       }
       imv_viewport_set_title(&view, title);

--- a/src/main.c
+++ b/src/main.c
@@ -514,14 +514,16 @@ int main(int argc, char** argv)
 
     /* check if a new image is available to display */
     FIBITMAP *bmp;
-    int is_new_image;
-    if(imv_loader_get_image(&ldr, &bmp, &is_new_image)) {
+    int frame_number, num_frames;
+    if(imv_loader_get_image(&ldr, &bmp, &frame_number, &num_frames)) {
       imv_texture_set_image(&tex, bmp);
       iw = FreeImage_GetWidth(bmp);
       ih = FreeImage_GetWidth(bmp);
       FreeImage_Unload(bmp);
       need_redraw = 1;
-      need_rescale += is_new_image;
+      if(frame_number == 0) {
+        need_rescale = 1;
+      }
     }
 
     if(need_rescale) {
@@ -569,7 +571,10 @@ int main(int argc, char** argv)
       snprintf(title, sizeof(title), "imv - [%i/%i] [%ix%i] %s [%s]",
           nav.cur_path + 1, nav.num_paths, tex.width, tex.height,
           current_path, scaling_label[g_options.scaling]);
-      if(g_options.delay >= 1000) {
+      if(num_frames > 1) {
+        snprintf(title, sizeof(title), "%s [%i/%i]", title, frame_number + 1,
+            num_frames);
+      } else if(g_options.delay >= 1000) {
         snprintf(title, sizeof(title), "%s [%lu/%lus]", title,
             delay_msec / 1000 + 1, g_options.delay / 1000);
       }

--- a/src/navigator.c
+++ b/src/navigator.c
@@ -109,6 +109,7 @@ void imv_navigator_add(struct imv_navigator *nav, const char *path,
         if(recursive) {
           imv_navigator_add(nav, path_buf, recursive);
         } else {
+          stat(path_buf, &path_info);
           add_item(nav, path_buf, path_info.st_mtim.tv_sec);
         }
       }


### PR DESCRIPTION
This branch changes the way `imv` deals with animated GIFs during slideshow. Right now `imv` shows animation until timeout for the slide is reached. Thus if animation is longer then timeout duration, it is just cut short. In my understanding, this is not what user expects: instead user may expect one of two things:

1. Play animation *at least* once.
2. Play animation *exactly* once.

Both options make sense in some circumstances. Provided that playing animation *exactly* once makes sense without slideshow, I added an option for entering this mode; it is enabled by `-1` flag.

During development of these features I've also made two unrelated changes:

1. Simplified title and captions printing.
2. Fixed uninitialized use of `last_time` variable.

I did not bother transplanting these changes to the main branch because I believe that this branch should be merged fully.