### PR TITLE
Fix the linking order of tests in the Makefile for --as-needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ $(BUILDDIR)/%.o: src/%.c
 
 $(BUILDDIR)/test_%: test/%.c src/%.c
 	@echo "BUILDING $@"
-	$(MUTE)$(CC) -o $@ -Isrc $(TFLAGS) $(LDFLAGS) -lcmocka $^
+	$(MUTE)$(CC) -o $@ -Isrc $(TFLAGS) $^ $(LDFLAGS) -lcmocka
 
 check: $(BUILDDIR) $(TESTS)
 	@echo "RUNNING TESTS"


### PR DESCRIPTION
When '--as-needed' linker flag is added to LDFLAGS, linker strips out
the symbols from the libraries needed for the tests due to the order
in which the libraries appear on the command line. List the source
files before the libraries to fix the linking issue.

For more information, see:
https://wiki.gentoo.org/wiki/Project:Quality_Assurance/As-needed#Importance_of_linking_order

Signed-off-by: Göktürk Yüksek <gokturk@gentoo.org>