### PR TITLE
Store getopt() return in a signed variable

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -103,7 +103,8 @@ static void parse_args(int argc, char** argv)
   /* Do not print getopt errors */
   opterr = 0;
 
-  char *argp, *ep = *argv, o;
+  char *argp, *ep = *argv;
+  int o;
 
   while((o = getopt(argc, argv, "firasSudxhln:b:e:t:")) != -1) {
     switch(o) {


### PR DESCRIPTION
On certain platforms, like armv7h, [a char may be unsigned](http://stackoverflow.com/questions/2054939/is-char-signed-or-unsigned-by-default#2054941). The loop for getopt would loop forever because:
```
     (char)-1 => 255 and 255 != -1
```
A signed char also worked. I don't know what that would mean for performance or portability. int feels simpler to me.

I'm using [Arch Linux ARM on the Samsung Chromebook 2](https://archlinuxarm.org/platforms/armv7/samsung/samsung-chromebook-2), which is armv7h. Not sure about other ARM platforms.