### PR TITLE
Add "jump to image feature"

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -175,7 +175,11 @@ static void parse_args(int argc, char** argv)
 #define define_jump(key) \
   case concat(SDLK_KP_, key):\
   case concat(SDLK_, key):\
-    value = value * 10 + key;\
+    if(value <= 0) { \
+      value = key; \
+    } else { \
+      value = value * 10 + key;\
+    } \
     delay_msec = 0;\
     break;
 
@@ -354,7 +358,7 @@ int main(int argc, char** argv)
   int quit = 0;
 
   /* Accumulator for "goto" */
-  int value = 0;
+  int value = -1;
 
   while(!quit) {
     /* handle any input/window events sent by SDL */
@@ -372,12 +376,14 @@ int main(int argc, char** argv)
               break;
             case SDLK_LEFTBRACKET:
             case SDLK_LEFT:
+              value = -1;
               imv_navigator_select_rel(&nav, -1);
               /* reset slideshow delay */
               delay_msec = 0;
               break;
             case SDLK_RIGHTBRACKET:
             case SDLK_RIGHT:
+              value = -1;
               imv_navigator_select_rel(&nav, 1);
               /* reset slideshow delay */
               delay_msec = 0;
@@ -386,14 +392,17 @@ int main(int argc, char** argv)
             case SDLK_PLUS:
             case SDLK_i:
             case SDLK_UP:
+              value = -1;
               imv_viewport_zoom(&view, &tex, IMV_ZOOM_KEYBOARD, 1);
               break;
             case SDLK_MINUS:
             case SDLK_o:
             case SDLK_DOWN:
+              value = -1;
               imv_viewport_zoom(&view, &tex, IMV_ZOOM_KEYBOARD, -1);
               break;
             case SDLK_s:
+              value = -1;
               if(!e.key.repeat) {
                 if((g_options.scaling += 1) > FULL) {
                   g_options.scaling = NONE;
@@ -401,34 +410,42 @@ int main(int argc, char** argv)
               }
             /* FALLTHROUGH */
             case SDLK_r:
+              value = -1;
               if(!e.key.repeat) {
                 need_rescale = 1;
                 need_redraw = 1;
               }
               break;
             case SDLK_a:
+              value = -1;
               if(!e.key.repeat) {
                 imv_viewport_scale_to_actual(&view, &tex);
               }
               break;
             case SDLK_c:
+              value = -1;
               if(!e.key.repeat) {
                 imv_viewport_center(&view, &tex);
               }
               break;
             case SDLK_j:
+              value = -1;
               imv_viewport_move(&view, 0, -50);
               break;
             case SDLK_k:
+              value = -1;
               imv_viewport_move(&view, 0, 50);
               break;
             case SDLK_h:
+              value = -1;
               imv_viewport_move(&view, 50, 0);
               break;
             case SDLK_l:
+              value = -1;
               imv_viewport_move(&view, -50, 0);
               break;
             case SDLK_x:
+              value = -1;
               if(!e.key.repeat) {
                 char* path = strdup(imv_navigator_selection(&nav));
                 imv_navigator_remove(&nav, path);
@@ -446,30 +463,36 @@ int main(int argc, char** argv)
               }
               break;
             case SDLK_f:
+              value = -1;
               if(!e.key.repeat) {
                 imv_viewport_toggle_fullscreen(&view);
               }
               break;
             case SDLK_PERIOD:
+              value = -1;
               imv_loader_load_next_frame(&ldr);
               break;
             case SDLK_SPACE:
+              value = -1;
               if(!e.key.repeat) {
                 imv_viewport_toggle_playing(&view);
               }
               break;
             case SDLK_p:
+              value = -1;
               if(!e.key.repeat) {
                 puts(imv_navigator_selection(&nav));
               }
               break;
             case SDLK_d:
+              value = -1;
               if(!e.key.repeat) {
                 g_options.overlay = !g_options.overlay;
                 need_redraw = 1;
               }
               break;
             case SDLK_t:
+              value = -1;
               if(e.key.keysym.mod & (KMOD_SHIFT|KMOD_CAPS)) {
                 if(g_options.delay >= 1000) {
                   g_options.delay -= 1000;
@@ -491,8 +514,10 @@ int main(int argc, char** argv)
             define_jump(9)
             case SDLK_KP_ENTER:
             case SDLK_RETURN:
-              imv_navigator_select_abs(&nav, value - 1);
-              value = 0;
+              if(value >= 0){
+                imv_navigator_select_abs(&nav, value - 1);
+              }
+              value = -1;
               delay_msec = 0;
               break;
           }

--- a/src/main.c
+++ b/src/main.c
@@ -179,6 +179,13 @@ static void parse_args(int argc, char** argv)
       value = key; \
     } else { \
       value = value * 10 + key;\
+      jmp_txt_col.g = 255; \
+      jmp_txt_col.b = 255; \
+      if(value > nav.num_paths) { \
+        value = nav.num_paths; \
+        jmp_txt_col.g = 0; \
+        jmp_txt_col.b = 0; \
+      } \
     } \
     delay_msec = 0;\
     need_redraw = 1;\
@@ -360,6 +367,7 @@ int main(int argc, char** argv)
 
   /* Accumulator for "goto" */
   int value = -1;
+  SDL_Color jmp_txt_col = {255,255,255,255};
 
   while(!quit) {
     /* handle any input/window events sent by SDL */
@@ -690,17 +698,13 @@ int main(int argc, char** argv)
             title + strlen("imv - "));
       }
       if(font && value >= 0) {
-        printf("Drawing\n");
-        SDL_Color fg = {255,255,255,255};
         SDL_Color bg = {0,0,0,160};
-        // x = ww - strlen(txt) * font size
-        // y = font size + 10% (padding)
         int size = TTF_FontHeight(font);
         char txt[50];
         sprintf(txt, "Jump to image %d", value);
         imv_printf(renderer, font,
                    0,
-                   size + (0.1 * size), &fg, &bg,
+                   size + (0.1 * size), &jmp_txt_col, &bg,
                    "Jump to image %d", value);
       }
 

--- a/src/main.c
+++ b/src/main.c
@@ -177,6 +177,8 @@ static void parse_args(int argc, char** argv)
   case concat(SDLK_, key):\
     if(value <= 0) { \
       value = key; \
+      jmp_txt_col.g = 255; \
+      jmp_txt_col.b = 255; \
     } else { \
       value = value * 10 + key;\
       jmp_txt_col.g = 255; \

--- a/src/main.c
+++ b/src/main.c
@@ -170,6 +170,15 @@ static void parse_args(int argc, char** argv)
   }
 }
 
+#define _concat(a, n) a##n
+#define concat(a, n) _concat(a, n)
+#define define_jump(key) \
+  case concat(SDLK_KP_, key):\
+  case concat(SDLK_, key):\
+    value = value * 10 + key;\
+    delay_msec = 0;\
+    break;
+
 int main(int argc, char** argv)
 {
   struct imv_navigator nav;
@@ -470,56 +479,16 @@ int main(int argc, char** argv)
               }
               need_redraw = 1;
               break;
-            case SDLK_KP_0:
-            case SDLK_0:
-              value = value * 10;
-              delay_msec = 0;
-              break;
-            case SDLK_KP_1:
-            case SDLK_1:
-              value = value * 10 + 1;
-              delay_msec = 0;
-              break;
-            case SDLK_KP_2:
-            case SDLK_2:
-              value = value * 10 + 2;
-              delay_msec = 0;
-              break;
-            case SDLK_KP_3:
-            case SDLK_3:
-              value = value * 10 + 3;
-              delay_msec = 0;
-              break;
-            case SDLK_KP_4:
-            case SDLK_4:
-              value = value * 10 + 4;
-              delay_msec = 0;
-              break;
-            case SDLK_KP_5:
-            case SDLK_5:
-              value = value * 10 + 5;
-              delay_msec = 0;
-              break;
-            case SDLK_KP_6:
-            case SDLK_6:
-              value = value * 10 + 6;
-              delay_msec = 0;
-              break;
-            case SDLK_KP_7:
-            case SDLK_7:
-              value = value * 10 + 7;
-              delay_msec = 0;
-              break;
-            case SDLK_KP_8:
-            case SDLK_8:
-              value = value * 10 + 8;
-              delay_msec = 0;
-              break;
-            case SDLK_KP_9:
-            case SDLK_9:
-              value = value * 10 + 9;
-              delay_msec = 0;
-              break;
+            define_jump(0)
+            define_jump(1)
+            define_jump(2)
+            define_jump(3)
+            define_jump(4)
+            define_jump(5)
+            define_jump(6)
+            define_jump(7)
+            define_jump(8)
+            define_jump(9)
             case SDLK_KP_ENTER:
             case SDLK_RETURN:
               imv_navigator_select_abs(&nav, value - 1);

--- a/src/main.c
+++ b/src/main.c
@@ -531,6 +531,9 @@ int main(int argc, char** argv)
               value = -1;
               delay_msec = 0;
               break;
+            default:
+              value = -1;
+              break;
           }
           break;
         case SDL_MOUSEWHEEL:

--- a/src/main.c
+++ b/src/main.c
@@ -181,6 +181,7 @@ static void parse_args(int argc, char** argv)
       value = value * 10 + key;\
     } \
     delay_msec = 0;\
+    need_redraw = 1;\
     break;
 
 int main(int argc, char** argv)
@@ -687,6 +688,20 @@ int main(int argc, char** argv)
         SDL_Color bg = {0,0,0,160};
         imv_printf(renderer, font, 0, 0, &fg, &bg, "%s",
             title + strlen("imv - "));
+      }
+      if(font && value >= 0) {
+        printf("Drawing\n");
+        SDL_Color fg = {255,255,255,255};
+        SDL_Color bg = {0,0,0,160};
+        // x = ww - strlen(txt) * font size
+        // y = font size + 10% (padding)
+        int size = TTF_FontHeight(font);
+        char txt[50];
+        sprintf(txt, "Jump to image %d", value);
+        imv_printf(renderer, font,
+                   0,
+                   size + (0.1 * size), &fg, &bg,
+                   "Jump to image %d", value);
       }
 
       /* redraw complete, unset the flag */

--- a/src/main.c
+++ b/src/main.c
@@ -343,6 +343,10 @@ int main(int argc, char** argv)
   int iw = 0, ih = 0;
 
   int quit = 0;
+
+  /* Accumulator for "goto" */
+  int value = 0;
+
   while(!quit) {
     /* handle any input/window events sent by SDL */
     SDL_Event e;
@@ -465,6 +469,62 @@ int main(int argc, char** argv)
                 g_options.delay += 1000;
               }
               need_redraw = 1;
+              break;
+            case SDLK_KP_0:
+            case SDLK_0:
+              value = value * 10;
+              delay_msec = 0;
+              break;
+            case SDLK_KP_1:
+            case SDLK_1:
+              value = value * 10 + 1;
+              delay_msec = 0;
+              break;
+            case SDLK_KP_2:
+            case SDLK_2:
+              value = value * 10 + 2;
+              delay_msec = 0;
+              break;
+            case SDLK_KP_3:
+            case SDLK_3:
+              value = value * 10 + 3;
+              delay_msec = 0;
+              break;
+            case SDLK_KP_4:
+            case SDLK_4:
+              value = value * 10 + 4;
+              delay_msec = 0;
+              break;
+            case SDLK_KP_5:
+            case SDLK_5:
+              value = value * 10 + 5;
+              delay_msec = 0;
+              break;
+            case SDLK_KP_6:
+            case SDLK_6:
+              value = value * 10 + 6;
+              delay_msec = 0;
+              break;
+            case SDLK_KP_7:
+            case SDLK_7:
+              value = value * 10 + 7;
+              delay_msec = 0;
+              break;
+            case SDLK_KP_8:
+            case SDLK_8:
+              value = value * 10 + 8;
+              delay_msec = 0;
+              break;
+            case SDLK_KP_9:
+            case SDLK_9:
+              value = value * 10 + 9;
+              delay_msec = 0;
+              break;
+            case SDLK_KP_ENTER:
+            case SDLK_RETURN:
+              imv_navigator_select_abs(&nav, value - 1);
+              value = 0;
+              delay_msec = 0;
               break;
           }
           break;

--- a/src/navigator.c
+++ b/src/navigator.c
@@ -148,6 +148,21 @@ void imv_navigator_select_rel(struct imv_navigator *nav, int direction)
   return;
 }
 
+void imv_navigator_select_abs(struct imv_navigator *nav, int pos) {
+  if(pos == nav->cur_path) {
+    return;
+  }
+  if(pos < 0) {
+    pos = 0;
+  }
+  if(pos >= nav->num_paths) {
+    pos = nav->num_paths - 1;
+  }
+  nav->cur_path = pos;
+  nav->last_move_direction = pos < nav->cur_path ? -1 : 1;
+  nav->changed = 1;
+}
+
 void imv_navigator_remove(struct imv_navigator *nav, const char *path)
 {
   int removed = -1;

--- a/src/navigator.h
+++ b/src/navigator.h
@@ -53,6 +53,12 @@ const char *imv_navigator_selection(struct imv_navigator *nav);
 /* Change the currently selected path. dir = -1 for previous, 1 for next. */
 void imv_navigator_select_rel(struct imv_navigator *nav, int dir);
 
+/* Change the current selected path.
+ * if pos < 0 go to the first image.
+ * if pos > num_path go to the last image
+ */
+void imv_navigator_select_abs(struct imv_navigator *nav, int pos);
+
 /* Removes the given path. The current selection is updated if necessary,
  * based on the last direction the selection moved. */
 void imv_navigator_remove(struct imv_navigator *nav, const char *path);


### PR DESCRIPTION
Jump to a random image by typing (with the keypad*) its number in the image list.
Pressing a number key will start recording where to jump.
Pressing the enter key will jump to the image.
Pressing any other key will cancel the jump.
Trying to jump passed the last image will jump to the last image: when trying to enter a number higher than the size of the image list, the number will be set the last image (and the text will be displayed in red).

\* I didn't manage to make it work with non-keypad number