### PR TITLE
Prevent scrolling images indefinitely off-screen

### DIFF
--- a/src/imv.c
+++ b/src/imv.c
@@ -722,7 +722,7 @@ static void handle_event(struct imv *imv, SDL_Event *event)
       break;
     case SDL_MOUSEMOTION:
       if(event->motion.state & SDL_BUTTON_LMASK) {
-        imv_viewport_move(imv->view, event->motion.xrel, event->motion.yrel);
+        imv_viewport_move(imv->view, event->motion.xrel, event->motion.yrel, imv->texture);
       }
       SDL_ShowCursor(SDL_ENABLE);
       break;
@@ -815,7 +815,7 @@ void command_pan(struct imv_list *args, void *data)
   long int x = strtol(args->items[1], NULL, 10);
   long int y = strtol(args->items[2], NULL, 10);
 
-  imv_viewport_move(imv->view, x, y);
+  imv_viewport_move(imv->view, x, y, imv->texture);
 }
 
 void command_select_rel(struct imv_list *args, void *data)

--- a/src/viewport.c
+++ b/src/viewport.c
@@ -57,12 +57,29 @@ void imv_viewport_scale_to_actual(struct imv_viewport *view, const struct imv_te
   imv_viewport_center(view, tex);
 }
 
-void imv_viewport_move(struct imv_viewport *view, int x, int y)
+void imv_viewport_move(struct imv_viewport *view, int x, int y,
+    const struct imv_texture *tex)
 {
   view->x += x;
   view->y += y;
   view->redraw = 1;
   view->locked = 1;
+  int w = (int)((double)tex->width * view->scale);
+  int h = (int)((double)tex->height * view->scale);
+  int ww, wh;
+  SDL_GetWindowSize(view->window, &ww, &wh);
+  if (view->x < -w) {
+    view->x = -w;
+  }
+  if (view->x > ww) {
+    view->x = ww;
+  }
+  if (view->y < -h) {
+    view->y = -h;
+  }
+  if (view->y > wh) {
+    view->y = wh;
+  }
 }
 
 void imv_viewport_zoom(struct imv_viewport *view, const struct imv_texture *tex, enum imv_zoom_source src, int amount)

--- a/src/viewport.h
+++ b/src/viewport.h
@@ -52,8 +52,10 @@ void imv_viewport_toggle_playing(struct imv_viewport *view);
 /* Reset the viewport to its initial settings */
 void imv_viewport_reset(struct imv_viewport *view);
 
-/* Pan the view by the given amounts */
-void imv_viewport_move(struct imv_viewport *view, int x, int y);
+/* Pan the view by the given amounts without letting the texture get too far
+ * off-screen */
+void imv_viewport_move(struct imv_viewport *view, int x, int y,
+    const struct imv_texture *tex);
 
 /* Zoom the view by the given amount. imv_texture* is used to get the image
  * dimensions */


### PR DESCRIPTION
With this change, if you scroll the image well beyond the viewport,
scrolling any amount in the other direction will immediately bring it
back on screen.