### PR TITLE
Multiple commands per bind

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ People who have contributed to imv:
  * Dmitrij D. Czarkoff
  * Jose Diez
  * Kenneth Hanley
+ * Julian Heinzel
  * Hannes Körber
  * Aleksandra Kosiacka
  * Michal Koutenský

--- a/README.md
+++ b/README.md
@@ -51,15 +51,16 @@ you like.
 In your imv config:
 
     [binds]
-    <Shift+x> = exec rm $imv_current_file
+    <Shift+x> = exec rm "$imv_current_file"
+    <Shift+x> = close
 
-Then press 'X' within imv to delete the image.
+Then press 'X' within imv to delete the image and close it.
 
 #### Rotate an image
 In your imv config:
 
     [binds]
-    <Shift+r> = exec mogrify -rotate 90 $imv_current_file
+    <Shift+r> = exec mogrify -rotate 90 "$imv_current_file"
 
 Then press 'R' within imv to rotate the image 90 degrees using imagemagick.
 

--- a/doc/imv.5.txt
+++ b/doc/imv.5.txt
@@ -96,7 +96,8 @@ Binds
 The *[binds]* section allows custom key bindings to be added to imv.
 
 Binds are in the format 'key combination = command'. A key combination can
-consist of multiple keys in succession.
+consist of multiple keys in succession. If there is more then one command
+defined for a given key combination, they are executed one after another.
 
 Single keys such as 'q' are just that: 'q = quit' will bind the 'q' key to the
 'quit' command.

--- a/src/binds.c
+++ b/src/binds.c
@@ -51,6 +51,7 @@ struct imv_binds *imv_binds_create(void)
 void imv_binds_free(struct imv_binds *binds)
 {
   destroy_bind_node(&binds->bind_tree);
+  list_deep_free(binds->keys);
   free(binds);
 }
 
@@ -83,7 +84,7 @@ enum bind_result imv_binds_add(struct imv_binds *binds, const struct list *keys,
       /* Create our new node */
       next_node = malloc(sizeof(struct bind_node));
       init_bind_node(next_node);
-      next_node->key = strdup(keys->items[i]);
+      next_node->key = keys->items[i];
       list_append(node->suffixes, next_node);
     } else {
       next_node = node->suffixes->items[child_index];

--- a/src/binds.h
+++ b/src/binds.h
@@ -32,7 +32,7 @@ const struct list *imv_bind_input_buffer(struct imv_binds *binds);
 void imv_bind_clear_input(struct imv_binds *binds);
 
 /* Handle an input event, if a bind is triggered, return its command */
-const char *imv_bind_handle_event(struct imv_binds *binds, const SDL_Event *event);
+struct list *imv_bind_handle_event(struct imv_binds *binds, const SDL_Event *event);
 
 /* Convert a string (such as from a config) to a key list */
 struct list *imv_bind_parse_keys(const char *keys);

--- a/src/commands.c
+++ b/src/commands.c
@@ -54,8 +54,8 @@ int imv_command_exec(struct imv_commands *cmds, struct list *commands, void *dat
     struct list *args = list_from_string(command, ' ');
 
     if(args->len > 0) {
-      for(size_t i = 0; i < cmds->command_list->len; ++i) {
-        struct command *cmd = cmds->command_list->items[i];
+      for(size_t j = 0; j < cmds->command_list->len; ++j) {
+        struct command *cmd = cmds->command_list->items[j];
         if(!strcmp(cmd->command, args->items[0])) {
           if(cmd->handler) {
             /* argstr = all args as a single string */
@@ -63,10 +63,10 @@ int imv_command_exec(struct imv_commands *cmds, struct list *commands, void *dat
             cmd->handler(args, argstr, data);
             ret = 0;
           } else if(cmd->alias) {
-            struct list *commands = list_create();
-            list_append(commands, cmd->alias);
-            ret = imv_command_exec(cmds, commands, data);
-            list_free(commands);
+            struct list *command_list = list_create();
+            list_append(command_list, cmd->alias);
+            ret = imv_command_exec(cmds, command_list, data);
+            list_free(command_list);
           }
           break;
         }

--- a/src/commands.c
+++ b/src/commands.c
@@ -46,29 +46,35 @@ void imv_command_alias(struct imv_commands *cmds, const char *command, const cha
   list_append(cmds->command_list, cmd);
 }
 
-int imv_command_exec(struct imv_commands *cmds, const char *command, void *data)
+int imv_command_exec(struct imv_commands *cmds, struct list *commands, void *data)
 {
-  struct list *args = list_from_string(command, ' ');
   int ret = 1;
+  for(size_t i = 0; i < commands->len; ++i) {
+    const char *command = commands->items[i];
+    struct list *args = list_from_string(command, ' ');
 
-  if(args->len > 0) {
-    for(size_t i = 0; i < cmds->command_list->len; ++i) {
-      struct command *cmd = cmds->command_list->items[i];
-      if(!strcmp(cmd->command, args->items[0])) {
-        if(cmd->handler) {
-          /* argstr = all args as a single string */
-          const char *argstr = command + strlen(cmd->command) + 1;
-          cmd->handler(args, argstr, data);
-          ret = 0;
-        } else if(cmd->alias) {
-          ret = imv_command_exec(cmds, cmd->alias, data);
+    if(args->len > 0) {
+      for(size_t i = 0; i < cmds->command_list->len; ++i) {
+        struct command *cmd = cmds->command_list->items[i];
+        if(!strcmp(cmd->command, args->items[0])) {
+          if(cmd->handler) {
+            /* argstr = all args as a single string */
+            const char *argstr = command + strlen(cmd->command) + 1;
+            cmd->handler(args, argstr, data);
+            ret = 0;
+          } else if(cmd->alias) {
+            struct list *commands = list_create();
+            list_append(commands, cmd->alias);
+            ret = imv_command_exec(cmds, commands, data);
+            list_free(commands);
+          }
+          break;
         }
-        break;
       }
     }
+    list_deep_free(args);
   }
 
-  list_deep_free(args);
   return ret;
 }
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -11,7 +11,8 @@ struct imv_commands *imv_commands_create(void);
 void imv_commands_free(struct imv_commands *cmds);
 void imv_command_register(struct imv_commands *cmds, const char *command, void (*handler)(struct list*, const char*, void*));
 void imv_command_alias(struct imv_commands *cmds, const char *command, const char *alias);
-int imv_command_exec(struct imv_commands *cmds, struct list *commands, void *data);
+int imv_command_exec(struct imv_commands *cmds, const char *command, void *data);
+int imv_command_exec_list(struct imv_commands *cmds, struct list *commands, void *data);
 
 #endif
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -11,7 +11,7 @@ struct imv_commands *imv_commands_create(void);
 void imv_commands_free(struct imv_commands *cmds);
 void imv_command_register(struct imv_commands *cmds, const char *command, void (*handler)(struct list*, const char*, void*));
 void imv_command_alias(struct imv_commands *cmds, const char *command, const char *alias);
-int imv_command_exec(struct imv_commands *cmds, const char *command, void *data);
+int imv_command_exec(struct imv_commands *cmds, struct list *commands, void *data);
 
 #endif
 

--- a/src/imv.c
+++ b/src/imv.c
@@ -760,10 +760,14 @@ static void handle_event(struct imv *imv, SDL_Event *event)
   }
 
   switch(event->type) {
-    case SDL_QUIT:
-      imv_command_exec(imv->commands, "quit", imv);
+    case SDL_QUIT: {
+      /* new scope needed in order to declare variables in a switch statement */
+      struct list *commands = list_create();
+      list_append(commands, "quit");
+      imv_command_exec(imv->commands, commands, imv);
+      list_free(commands);
       break;
-
+    }
     case SDL_TEXTINPUT:
       strncat(imv->input_buffer, event->text.text, command_buffer_len - 1);
       imv->need_redraw = true;
@@ -780,8 +784,11 @@ static void handle_event(struct imv *imv, SDL_Event *event)
           imv->input_buffer = NULL;
           imv->need_redraw = true;
         } else if(event->key.keysym.sym == SDLK_RETURN) {
-          imv_command_exec(imv->commands, imv->input_buffer, imv);
+          struct list *commands = list_create();
+          list_append(commands, imv->input_buffer);
+          imv_command_exec(imv->commands, commands, imv);
           SDL_StopTextInput();
+          list_free(commands);
           free(imv->input_buffer);
           imv->input_buffer = NULL;
           imv->need_redraw = true;
@@ -806,9 +813,9 @@ static void handle_event(struct imv *imv, SDL_Event *event)
           }
           break;
         default: { /* braces to allow const char *cmd definition */
-          const char *cmd = imv_bind_handle_event(imv->binds, event);
-          if(cmd) {
-            imv_command_exec(imv->commands, cmd, imv);
+          struct list *cmds = imv_bind_handle_event(imv->binds, event);
+          if(cmds) {
+            imv_command_exec(imv->commands, cmds, imv);
           }
         }
       }

--- a/src/imv.c
+++ b/src/imv.c
@@ -129,6 +129,7 @@ static const char *add_bind(struct imv *imv, const char *keys, const char *comma
   }
 
   enum bind_result result = imv_binds_add(imv->binds, list, command);
+  list_free(list);
 
   if (result == BIND_SUCCESS) {
     return NULL;
@@ -244,10 +245,14 @@ struct imv *imv_create(void)
 void imv_free(struct imv *imv)
 {
   free(imv->font_name);
+  free(imv->title_text);
+  free(imv->overlay_text);
   imv_binds_free(imv->binds);
   imv_navigator_free(imv->navigator);
   imv_loader_free(imv->loader);
   imv_commands_free(imv->commands);
+  imv_viewport_free(imv->view);
+  imv_image_free(imv->image);
   if(imv->stdin_image_data) {
     free(imv->stdin_image_data);
   }
@@ -928,6 +933,7 @@ static char *get_config_path(void)
     wordexp_t word;
     if(wordexp(config_paths[i], &word, 0) == 0) {
       if (!word.we_wordv[0]) {
+        wordfree(&word);
         continue;
       }
 
@@ -1073,7 +1079,7 @@ static int handle_ini_value(void *user, const char *section, const char *name,
 
 bool imv_load_config(struct imv *imv)
 {
-  const char *path = get_config_path();
+  char *path = get_config_path();
   if(!path) {
     /* no config, no problem - we have defaults */
     return true;
@@ -1087,6 +1093,7 @@ bool imv_load_config(struct imv *imv)
     fprintf(stderr, "Error in config file: %s:%d\n", path, err);
     return false;
   }
+  free(path);
   return true;
 }
 

--- a/src/imv.c
+++ b/src/imv.c
@@ -765,14 +765,9 @@ static void handle_event(struct imv *imv, SDL_Event *event)
   }
 
   switch(event->type) {
-    case SDL_QUIT: {
-      /* new scope needed in order to declare variables in a switch statement */
-      struct list *commands = list_create();
-      list_append(commands, "quit");
-      imv_command_exec(imv->commands, commands, imv);
-      list_free(commands);
+    case SDL_QUIT:
+      imv_command_exec(imv->commands, "quit", imv);
       break;
-    }
     case SDL_TEXTINPUT:
       strncat(imv->input_buffer, event->text.text, command_buffer_len - 1);
       imv->need_redraw = true;
@@ -791,7 +786,7 @@ static void handle_event(struct imv *imv, SDL_Event *event)
         } else if(event->key.keysym.sym == SDLK_RETURN) {
           struct list *commands = list_create();
           list_append(commands, imv->input_buffer);
-          imv_command_exec(imv->commands, commands, imv);
+          imv_command_exec_list(imv->commands, commands, imv);
           SDL_StopTextInput();
           list_free(commands);
           free(imv->input_buffer);
@@ -820,7 +815,7 @@ static void handle_event(struct imv *imv, SDL_Event *event)
         default: { /* braces to allow const char *cmd definition */
           struct list *cmds = imv_bind_handle_event(imv->binds, event);
           if(cmds) {
-            imv_command_exec(imv->commands, cmds, imv);
+            imv_command_exec_list(imv->commands, cmds, imv);
           }
         }
       }

--- a/src/list.c
+++ b/src/list.c
@@ -12,6 +12,7 @@ struct list *list_create(void)
 void list_free(struct list *list)
 {
   free(list->items);
+  free(list);
 }
 
 void list_deep_free(struct list *list)


### PR DESCRIPTION
These commits address the feature request #130 for combining commands, because I really miss using <kbd>Shift</kbd>+<kbd>x</kbd> to both delete the current image and skip to the next one.
I thought the easiest way to do this would be to just change `bind_node.command` from a `char*` to a `struct list*` of `char*`s. That way, redefining a key bind does not overwrite the current one, but adds to the list. @eXeC64 I'd love to hear your opinion on this; though everything works on my end, maybe I overlooked something important while doing that change.
Also I noticed and fixed several memory leaks while checking the code.