### PR TITLE
Tidied up, fixed partial bind issue

### DIFF
--- a/src/binds.c
+++ b/src/binds.c
@@ -231,7 +231,7 @@ static int print_event(char *buf, size_t len, const SDL_Event *event)
     keyname = "RightSquareBracket";
   } else if(strlen(keyname) == 1 && isalpha(*keyname)) {
     singlekey[0] = tolower(*keyname);
-    keyname = &singlekey[0];
+    keyname = singlekey;
   }
 
   return snprintf(buf, len, "%s%s", prefix, keyname);

--- a/src/image.c
+++ b/src/image.c
@@ -29,6 +29,9 @@ struct imv_image *imv_image_create(SDL_Renderer *r)
 
 void imv_image_free(struct imv_image *image)
 {
+  if(!image) {
+    return;
+  }
   if(image->num_chunks > 0) {
     for(int i = 0; i < image->num_chunks; ++i) {
       SDL_DestroyTexture(image->chunks[i]);

--- a/src/util.c
+++ b/src/util.c
@@ -115,7 +115,7 @@ void imv_printf(SDL_Renderer *renderer, TTF_Font *font, int x, int y,
   va_start(args, fmt);
   vsnprintf(line, sizeof(line), fmt, args);
 
-  SDL_Surface *surf = TTF_RenderUTF8_Blended(font, &line[0], *fg);
+  SDL_Surface *surf = TTF_RenderUTF8_Blended(font, line, *fg);
   SDL_Texture *tex = SDL_CreateTextureFromSurface(renderer, surf);
 
   SDL_Rect tex_rect = {0,0,0,0};


### PR DESCRIPTION
**Changes:**
- Changed &pointer[0] to pointer
- If a command exceeds the maximum length, none of the commands in that line will bind
- split_commands always returned `start` as `out`, so I adapted the function signature
- When a bind failed, imv_image_free caused a segmentation fault, so I added a check for NULL