### PR TITLE
Add rotation and flipping commands

### DIFF
--- a/doc/imv.1.txt
+++ b/doc/imv.1.txt
@@ -99,11 +99,8 @@ Commands can be entered by pressing *:*. imv supports the following commands:
 	'actual' resets the zoom to 100%, showing the image at its actual size.
 	Aliased to 'z'.
 
-*rotate* <amount>::
-	Rotate image clockwise by the given amount in degrees.
-
-*rotate_to* <angle>::
-	Rotate image clockwise to the given angle in degrees.
+*rotate* <'to'|'by'> <angle>::
+	Rotate image clockwise by/to the given amount in degrees.
 
 *flip* <'horizontal'|'vertical'>::
 	Flip image horizontally/vertically (across vertical/horizontal axis).

--- a/doc/imv.1.txt
+++ b/doc/imv.1.txt
@@ -99,6 +99,15 @@ Commands can be entered by pressing *:*. imv supports the following commands:
 	'actual' resets the zoom to 100%, showing the image at its actual size.
 	Aliased to 'z'.
 
+*rotate* <amount>::
+	Rotate image clockwise by the given amount in degrees.
+
+*rotate_to* <angle>::
+	Rotate image clockwise to the given angle in degrees.
+
+*flip* <'horizontal'|'vertical'>::
+	Flip image horizontally/vertically (across vertical/horizontal axis).
+
 *open* [-r] <paths ...>::
 	Add the given paths to the list of open images. If the '-r' option is
 	specified, do so recursively. Shell expansions may be used.

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -8,9 +8,9 @@
 #include <cairo/cairo.h>
 #include <pango/pangocairo.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 
 #ifdef IMV_BACKEND_LIBRSVG
 #include <librsvg/rsvg.h>
@@ -204,7 +204,9 @@ static int convert_pixelformat(enum imv_pixelformat fmt)
 static void draw_bitmap(struct imv_canvas *canvas,
                         struct imv_bitmap *bitmap,
                         int bx, int by, double scale,
-                        enum upscaling_method upscaling_method, bool cache_invalidated)
+                        double rotation, bool mirrored,
+                        enum upscaling_method upscaling_method,
+                        bool cache_invalidated)
 {
   GLint viewport[4];
   glGetIntegerv(GL_VIEWPORT, viewport);
@@ -249,6 +251,15 @@ static void draw_bitmap(struct imv_canvas *canvas,
   const int top = by;
   const int right = left + bitmap->width * scale;
   const int bottom = top + bitmap->height * scale;
+  const int center_x = left + bitmap->width * scale / 2;
+  const int center_y = top + bitmap->height * scale / 2;
+
+  glTranslated(center_x, center_y, 0);
+  if (mirrored) {
+    glScaled(-1, 1, 1);
+  }
+  glRotated(-rotation, 0, 0, 1);
+  glTranslated(-center_x, -center_y, 0);
 
   glEnable(GL_BLEND);
   glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -273,11 +284,14 @@ RsvgHandle *imv_image_get_svg(const struct imv_image *image);
 
 void imv_canvas_draw_image(struct imv_canvas *canvas, struct imv_image *image,
                            int x, int y, double scale,
-                           enum upscaling_method upscaling_method, bool cache_invalidated)
+                           double rotation, bool mirrored,
+                           enum upscaling_method upscaling_method,
+                           bool cache_invalidated)
 {
   struct imv_bitmap *bitmap = imv_image_get_bitmap(image);
   if (bitmap) {
-    draw_bitmap(canvas, bitmap, x, y, scale, upscaling_method, cache_invalidated);
+    draw_bitmap(canvas, bitmap, x, y, scale, rotation, mirrored,
+                upscaling_method, cache_invalidated);
     return;
   }
 

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -258,7 +258,7 @@ static void draw_bitmap(struct imv_canvas *canvas,
   if (mirrored) {
     glScaled(-1, 1, 1);
   }
-  glRotated(-rotation, 0, 0, 1);
+  glRotated(rotation, 0, 0, 1);
   glTranslated(-center_x, -center_y, 0);
 
   glEnable(GL_BLEND);

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -1,7 +1,7 @@
-#include <stdbool.h>
-
 #ifndef IMV_CANVAS_H
 #define IMV_CANVAS_H
+
+#include <stdbool.h>
 
 struct imv_canvas;
 struct imv_image;
@@ -48,6 +48,8 @@ void imv_canvas_draw(struct imv_canvas *canvas);
 /* Blit the given image to the current OpenGL framebuffer */
 void imv_canvas_draw_image(struct imv_canvas *canvas, struct imv_image *image,
                            int x, int y, double scale,
-                           enum upscaling_method upscaling_method, bool cache_invalidated);
+                           double rotation, bool mirrored,
+                           enum upscaling_method upscaling_method,
+                           bool cache_invalidated);
 
 #endif

--- a/src/imv.c
+++ b/src/imv.c
@@ -180,7 +180,6 @@ static void command_prev(struct list *args, const char *argstr, void *data);
 static void command_goto(struct list *args, const char *argstr, void *data);
 static void command_zoom(struct list *args, const char *argstr, void *data);
 static void command_rotate(struct list *args, const char *argstr, void *data);
-static void command_rotate_to(struct list *args, const char *argstr, void *data);
 static void command_flip(struct list *args, const char *argstr, void *data);
 static void command_open(struct list *args, const char *argstr, void *data);
 static void command_close(struct list *args, const char *argstr, void *data);
@@ -501,7 +500,6 @@ struct imv *imv_create(void)
   imv_command_register(imv->commands, "goto", &command_goto);
   imv_command_register(imv->commands, "zoom", &command_zoom);
   imv_command_register(imv->commands, "rotate", &command_rotate);
-  imv_command_register(imv->commands, "rotate_to", &command_rotate_to);
   imv_command_register(imv->commands, "flip", &command_flip);
   imv_command_register(imv->commands, "open", &command_open);
   imv_command_register(imv->commands, "close", &command_close);
@@ -1512,19 +1510,14 @@ static void command_rotate(struct list *args, const char *argstr, void *data)
 {
   (void)argstr;
   struct imv *imv = data;
-  if (args->len == 2) {
-    double degrees = strtod(args->items[1], NULL);
-    imv_viewport_rotate(imv->view, degrees);
-  }
-}
-
-static void command_rotate_to(struct list *args, const char *argstr, void *data)
-{
-  (void)argstr;
-  struct imv *imv = data;
-  if (args->len == 2) {
-    double degrees = strtod(args->items[1], NULL);
-    imv_viewport_rotate_to(imv->view, degrees);
+  if (args->len == 3) {
+    if (!strcmp(args->items[1], "by")) {
+      double degrees = strtod(args->items[2], NULL);
+      imv_viewport_rotate_by(imv->view, degrees);
+    } else if (!strcmp(args->items[1], "to")) {
+      double degrees = strtod(args->items[2], NULL);
+      imv_viewport_rotate_to(imv->view, degrees);
+    }
   }
 }
 
@@ -1628,7 +1621,7 @@ static void command_reset(struct list *args, const char *argstr, void *data)
   (void)args;
   (void)argstr;
   struct imv *imv = data;
-  imv_viewport_rotate_to(imv->view, 0);
+  imv_viewport_reset_transform(imv->view);
   imv->need_rescale = true;
   imv->need_redraw = true;
 }

--- a/src/imv.c
+++ b/src/imv.c
@@ -1458,6 +1458,7 @@ static void command_next(struct list *args, const char *argstr, void *data)
   }
 
   imv_navigator_select_rel(imv->navigator, index);
+  imv_viewport_reset_transform(imv->view);
 
   imv->slideshow.elapsed = 0;
 }
@@ -1473,6 +1474,7 @@ static void command_prev(struct list *args, const char *argstr, void *data)
   }
 
   imv_navigator_select_rel(imv->navigator, -index);
+  imv_viewport_reset_transform(imv->view);
 
   imv->slideshow.elapsed = 0;
 }
@@ -1487,6 +1489,7 @@ static void command_goto(struct list *args, const char *argstr, void *data)
 
   long int index = strtol(args->items[1], NULL, 10);
   imv_navigator_select_abs(imv->navigator, index - 1);
+  imv_viewport_reset_transform(imv->view);
 
   imv->slideshow.elapsed = 0;
 }

--- a/src/viewport.c
+++ b/src/viewport.c
@@ -196,7 +196,7 @@ void imv_viewport_zoom(struct imv_viewport *view, const struct imv_image *image,
   view->locked = 1;
 }
 
-void imv_viewport_rotate(struct imv_viewport *view, double degrees) {
+void imv_viewport_rotate_by(struct imv_viewport *view, double degrees) {
   view->rotation += degrees;
 }
 
@@ -210,7 +210,12 @@ void imv_viewport_flip_h(struct imv_viewport *view) {
 
 void imv_viewport_flip_v(struct imv_viewport *view) {
   view->mirrored = !view->mirrored;
-  view->rotation = -(180.0 - view->rotation);
+  view->rotation = view->rotation - 180;
+}
+
+void imv_viewport_reset_transform(struct imv_viewport *view) {
+  view->mirrored = false;
+  view->rotation = 0;
 }
 
 void imv_viewport_center(struct imv_viewport *view, const struct imv_image *image)

--- a/src/viewport.c
+++ b/src/viewport.c
@@ -1,9 +1,12 @@
 #include "viewport.h"
 
+#include <stdbool.h>
 #include <stdlib.h>
 
 struct imv_viewport {
   double scale;
+  double rotation;
+  bool mirrored;
   struct {
     int width, height;
   } window; /* window dimensions */
@@ -32,6 +35,8 @@ struct imv_viewport *imv_viewport_create(int window_width, int window_height,
   view->buffer.width = buffer_width;
   view->buffer.height = buffer_height;
   view->scale = 1;
+  view->rotation = 0;
+  view->mirrored = false;
   view->x = view->y = view->redraw = 0;
   view->pan_factor_x = view->pan_factor_y = 0.5;
   view->playing = 1;
@@ -81,6 +86,20 @@ void imv_viewport_get_scale(struct imv_viewport *view, double *scale)
 {
   if(scale) {
     *scale = view->scale;
+  }
+}
+
+void imv_viewport_get_rotation(struct imv_viewport *view, double *rotation)
+{
+  if(rotation) {
+    *rotation = view->rotation;
+  }
+}
+
+void imv_viewport_get_mirrored(struct imv_viewport *view, bool *mirrored)
+{
+  if(mirrored) {
+    *mirrored = view->mirrored;
   }
 }
 
@@ -175,6 +194,23 @@ void imv_viewport_zoom(struct imv_viewport *view, const struct imv_image *image,
 
   view->redraw = 1;
   view->locked = 1;
+}
+
+void imv_viewport_rotate(struct imv_viewport *view, double degrees) {
+  view->rotation += degrees;
+}
+
+void imv_viewport_rotate_to(struct imv_viewport *view, double degrees) {
+  view->rotation = degrees;
+}
+
+void imv_viewport_flip_h(struct imv_viewport *view) {
+  view->mirrored = !view->mirrored;
+}
+
+void imv_viewport_flip_v(struct imv_viewport *view) {
+  view->mirrored = !view->mirrored;
+  view->rotation = -(180.0 - view->rotation);
 }
 
 void imv_viewport_center(struct imv_viewport *view, const struct imv_image *image)

--- a/src/viewport.h
+++ b/src/viewport.h
@@ -62,7 +62,7 @@ void imv_viewport_zoom(struct imv_viewport *view, const struct imv_image *image,
                        enum imv_zoom_source, int mouse_x, int mouse_y, int amount);
 
 /* Rotate the view by the given number of degrees */
-void imv_viewport_rotate(struct imv_viewport *view, double degrees);
+void imv_viewport_rotate_by(struct imv_viewport *view, double degrees);
 
 /* Rotate the view to the given number of degrees */
 void imv_viewport_rotate_to(struct imv_viewport *view, double degrees);
@@ -72,6 +72,9 @@ void imv_viewport_flip_h(struct imv_viewport *view);
 
 /* Flip vertically (across horizontal axis) */
 void imv_viewport_flip_v(struct imv_viewport *view);
+
+/* Flip vertically (across horizontal axis) */
+void imv_viewport_reset_transform(struct imv_viewport *view);
 
 /* Recenter the view to be in the middle of the image */
 void imv_viewport_center(struct imv_viewport *view,

--- a/src/viewport.h
+++ b/src/viewport.h
@@ -42,6 +42,12 @@ void imv_viewport_get_offset(struct imv_viewport *view, int *x, int *y);
 /* Fetch viewport scale */
 void imv_viewport_get_scale(struct imv_viewport *view, double *scale);
 
+/* Fetch viewport rotation */
+void imv_viewport_get_rotation(struct imv_viewport *view, double *rotation);
+
+/* Fetch viewport mirror status */
+void imv_viewport_get_mirrored(struct imv_viewport *view, bool *mirrored);
+
 /* Set the default pan_factor factor for the x and y position */
 void imv_viewport_set_default_pan_factor(struct imv_viewport *view, double pan_factor_x, double pan_factor_y);
 
@@ -54,6 +60,18 @@ void imv_viewport_move(struct imv_viewport *view, int x, int y,
  * dimensions */
 void imv_viewport_zoom(struct imv_viewport *view, const struct imv_image *image,
                        enum imv_zoom_source, int mouse_x, int mouse_y, int amount);
+
+/* Rotate the view by the given number of degrees */
+void imv_viewport_rotate(struct imv_viewport *view, double degrees);
+
+/* Rotate the view to the given number of degrees */
+void imv_viewport_rotate_to(struct imv_viewport *view, double degrees);
+
+/* Flip horizontally (across vertical axis) */
+void imv_viewport_flip_h(struct imv_viewport *view);
+
+/* Flip vertically (across horizontal axis) */
+void imv_viewport_flip_v(struct imv_viewport *view);
 
 /* Recenter the view to be in the middle of the image */
 void imv_viewport_center(struct imv_viewport *view,


### PR DESCRIPTION
Even though this was discussed in #92 I felt that solution was cumbersome and annoying if the image was not to be edited on disk. That approach would also be slow on large images.

These changes add commands for rotating by (arbitrary) angles and flipping horizontally and vertically. The actual transforms are just viewport transforms in the GL code.

The following commands are added:
```
rotate by <angle>
rotate to <angle>
flip horizontal
flip vertical
```