### PR TITLE
Enabling touch navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build/
 imv.1
 imv.5
 doc/imv-msg.1
+*.png
+*.jpg
+src/G*

--- a/src/viewport.c
+++ b/src/viewport.c
@@ -90,14 +90,9 @@ void imv_viewport_set_default_pan_factor(struct imv_viewport *view, double pan_f
   view->pan_factor_y = pan_factor_y;
 }
 
-void imv_viewport_move(struct imv_viewport *view, int x, int y,
+void imv_viewport_keep_onscreen(struct imv_viewport *view,
     const struct imv_image *image)
 {
-  input_xy_to_render_xy(view, &x, &y);
-  view->x += x;
-  view->y += y;
-  view->redraw = 1;
-  view->locked = 1;
   int w = (int)(imv_image_width(image) * view->scale);
   int h = (int)(imv_image_height(image) * view->scale);
   if (view->x < -w) {
@@ -114,6 +109,29 @@ void imv_viewport_move(struct imv_viewport *view, int x, int y,
   }
 }
 
+void imv_viewport_move(struct imv_viewport *view, int x, int y,
+    const struct imv_image *image)
+{
+  input_xy_to_render_xy(view, &x, &y);
+  view->x += x;
+  view->y += y;
+  view->redraw = 1;
+  view->locked = 1;
+  imv_viewport_keep_onscreen(view, image);
+}
+
+void imv_viewport_move_relative(struct imv_viewport *view,
+				int initial_x, int initial_y,
+				int delta_x, int delta_y,
+				struct imv_image *image)
+{
+  view->x = initial_x + delta_x;
+  view->y = initial_y + delta_y;
+  view->redraw = 1;
+  view->locked = 1;
+  imv_viewport_keep_onscreen(view, image);
+}
+
 void imv_viewport_zoom(struct imv_viewport *view, const struct imv_image *image,
                        enum imv_zoom_source src, int mouse_x, int mouse_y, int amount)
 {
@@ -124,7 +142,7 @@ void imv_viewport_zoom(struct imv_viewport *view, const struct imv_image *image,
   const int image_height = imv_image_height(image);
 
   /* x and y cordinates are relative to the image */
-  if(src == IMV_ZOOM_MOUSE) {
+  if(src == IMV_ZOOM_MOUSE || src == IMV_ZOOM_TOUCH) {
     input_xy_to_render_xy(view, &mouse_x, &mouse_y);
     x = mouse_x - view->x;
     y = mouse_y - view->y;
@@ -140,8 +158,12 @@ void imv_viewport_zoom(struct imv_viewport *view, const struct imv_image *image,
   const int wc_x = view->buffer.width/2;
   const int wc_y = view->buffer.height/2;
 
-  double delta_scale = 0.04 * view->buffer.width * amount / image_width;
-  view->scale += delta_scale;
+  if (src == IMV_ZOOM_TOUCH) {
+    view->scale = amount / 100.0f;
+  } else {
+    double delta_scale = 0.04 * view->buffer.width * amount / image_width;
+    view->scale += delta_scale;
+  }
 
   const double min_scale = 0.1;
   const double max_scale = 100;
@@ -203,7 +225,8 @@ void imv_viewport_center(struct imv_viewport *view, const struct imv_image *imag
   view->redraw = 1;
 }
 
-void imv_viewport_scale_to_window(struct imv_viewport *view, const struct imv_image *image)
+double imv_viewport_get_scale_to_window(struct imv_viewport *view,
+					const struct imv_image *image)
 {
   const int image_width = imv_image_width(image);
   const int image_height = imv_image_height(image);
@@ -212,12 +235,16 @@ void imv_viewport_scale_to_window(struct imv_viewport *view, const struct imv_im
 
   if(window_aspect > image_aspect) {
     /* Image will become too tall before it becomes too wide */
-    view->scale = (double)view->buffer.height / (double)image_height;
+    return (double)view->buffer.height / (double)image_height;
   } else {
     /* Image will become too wide before it becomes too tall */
-    view->scale = (double)view->buffer.width / (double)image_width;
+    return (double)view->buffer.width / (double)image_width;
   }
+}
 
+void imv_viewport_scale_to_window(struct imv_viewport *view, const struct imv_image *image)
+{
+  view->scale = imv_viewport_get_scale_to_window(view, image);
   imv_viewport_center(view, image);
   view->locked = 0;
 }

--- a/src/viewport.h
+++ b/src/viewport.h
@@ -17,7 +17,8 @@ enum scaling_mode {
 /* Used to signify how a a user requested a zoom */
 enum imv_zoom_source {
   IMV_ZOOM_MOUSE,
-  IMV_ZOOM_KEYBOARD
+  IMV_ZOOM_KEYBOARD,
+  IMV_ZOOM_TOUCH
 };
 
 /* Creates an instance of imv_viewport */
@@ -50,6 +51,10 @@ void imv_viewport_set_default_pan_factor(struct imv_viewport *view, double pan_f
 void imv_viewport_move(struct imv_viewport *view, int x, int y,
     const struct imv_image *image);
 
+/* Pan the view relatively by coordinates */
+void imv_viewport_move_relative(struct imv_viewport *view, int initial_x,
+    int initial_y, int delta_x, int delta_y, struct imv_image *image);
+
 /* Zoom the view by the given amount. imv_image* is used to get the image
  * dimensions */
 void imv_viewport_zoom(struct imv_viewport *view, const struct imv_image *image,
@@ -62,6 +67,10 @@ void imv_viewport_center(struct imv_viewport *view,
 /* Scale the view so that the image appears at its actual resolution */
 void imv_viewport_scale_to_actual(struct imv_viewport *view,
                                   const struct imv_image *image);
+
+/*get scale when scaled to window*/
+double imv_viewport_get_scale_to_window(struct imv_viewport *view,
+					const struct imv_image *image);
 
 /* Scale the view so that the image fits in the window */
 void imv_viewport_scale_to_window(struct imv_viewport *view,

--- a/src/window.h
+++ b/src/window.h
@@ -13,6 +13,11 @@ enum imv_event_type {
   IMV_EVENT_MOUSE_MOTION,
   IMV_EVENT_MOUSE_BUTTON,
   IMV_EVENT_MOUSE_SCROLL,
+  IMV_EVENT_TOUCH_TAP,
+  IMV_EVENT_TOUCH_ZOOM_START,
+  IMV_EVENT_TOUCH_ZOOM_CHANGE,
+  IMV_EVENT_TOUCH_PAN_START,
+  IMV_EVENT_TOUCH_PAN_CHANGE,
   IMV_EVENT_CUSTOM
 };
 
@@ -41,6 +46,18 @@ struct imv_event {
     struct {
       double dx, dy;
     } mouse_scroll;
+    struct {
+      double x,y;
+      int height, width;
+    } touch_tap;
+    struct {
+      double x,y;
+      double zoom;
+    } touch_zoom;
+    struct {
+      double initial_x, initial_y;
+      double current_x, current_y;
+    } touch_pan;
     void *custom;
   } data;
 };


### PR DESCRIPTION
Adds the touch navigation functionality as proposed in #138 .

* tap to left/right side to navigate to previous/next image
* tap into the middle to show overlay
* move single point to pan the image
* pinch in/out to zoom