### PR TITLE
README: Improve build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ Dependencies are determined by which backends and window systems are enabled
 when building `imv`. You can find a summary of which backends are available
 in [meson_options.txt](meson_options.txt)
 
-    $ meson builddir/
-    $ ninja -C builddir/
-    # ninja -C builddir/ install
+    $ meson build/
+    $ ninja -C build/
+    # ninja -C build/ install
 
 `--prefix` controls installation prefix.  If more control over installation
 paths is required, `--bindir`, `--mandir` and `--datadir` are


### PR DESCRIPTION
The .gitignore file ignores the directory build/, therefore it makes
most sense to use this directory in the example as well.