### PR TITLE
Sort directory entries alphabetically

### DIFF
--- a/src/navigator.c
+++ b/src/navigator.c
@@ -76,10 +76,11 @@ int imv_navigator_add(struct imv_navigator *nav, const char *path,
   if ((stat(path, &path_info) == 0) &&
       S_ISDIR(path_info.st_mode)) {
     int result = 0;
-    DIR *d = opendir(path);
-    if (d) {
-      struct dirent *dir;
-      while ((dir = readdir(d)) != NULL) {
+    struct dirent **dir_list;
+    int total_dirs = scandir(path, &dir_list, 0, alphasort);
+    if (total_dirs >= 0) {
+      for (int i = 0; i < total_dirs; ++i) {
+        struct dirent *dir = dir_list[i];
         if (strcmp(dir->d_name, "..") == 0 || strcmp(dir->d_name, ".") == 0) {
           continue;
         }
@@ -101,8 +102,9 @@ int imv_navigator_add(struct imv_navigator *nav, const char *path,
             break;
           }
         }
+        free(dir_list[i]);
       }
-      closedir(d);
+      free(dir_list);
     }
     return result;
   } else {


### PR DESCRIPTION
Hello. The way directories are sorted bothers me, so I changed it to sort the images alphabetically. The way it's implemented avoids bloat and complicating the codebase - it's a very minor edit.

I understand that users have always been able to sort directories however they like, by using `stdin` as described in #146. I just feel that the current default behaviour isn't ideal.

I've tried to stick to `imv`'s coding style, so hopefully there aren't any problems there.

As for licensing, I'm no lawyer, but I'm not sure a change so minor can be copyrighted in the first place. If that isn't the case, though, then I agree to place my code under the MIT licence.