### PR TITLE
FreeBSD: use librsvg2-rust instead of librsvg2

### DIFF
--- a/.builds/freebsd.yml
+++ b/.builds/freebsd.yml
@@ -8,7 +8,7 @@ packages:
   - graphics/libheif
   - graphics/libjpeg-turbo
   - graphics/libnsgif
-  - graphics/librsvg2
+  - graphics/librsvg2-rust
   - graphics/png
   - graphics/tiff
   - sysutils/cmocka


### PR DESCRIPTION
the library is rewritten in rust and on freebsd there is an other
package for it.