### PR TITLE
Add libheif dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Installation
 | libjpeg-turbo  |          | Optional. Provides JPEG support.               |
 | librsvg        | >=v2.44  | Optional. Provides SVG support.                |
 | libnsgif       |          | Optional. Provides animated GIF support.       |
+| libheif        |          | Optional. Provides HEIF support.               |
 
 Dependencies are determined by which backends and window systems are enabled
 when building `imv`. You can find a summary of which backends are available


### PR DESCRIPTION
Realized I forgot to update the README when adding HEIF support.