### PR TITLE
Use private mapping for memfd with keymap.

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -103,9 +103,12 @@ static void keyboard_keymap(void *data, struct wl_keyboard *keyboard,
   (void)keyboard;
   (void)format;
   struct imv_window *window = data;
-  char *src = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
-  imv_keyboard_set_keymap(window->keyboard, src);
-  munmap(src, size);
+  char *src = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
+
+  if (src != MAP_FAILED) {
+    imv_keyboard_set_keymap(window->keyboard, src);
+    munmap(src, size);
+  }
   close(fd);
 }
 


### PR DESCRIPTION
mmap with MAP_SHARED would fail if the compositor provides a read-only
descriptor with keymap. And at least weston applies F_SEAL_WRITE to the
memfd if supported by the platform.

Fixes #263
***
See also: https://gitlab.freedesktop.org/wayland/wayland/-/commit/905c0a341ddf0a885811d19e2b79c65a3f1d210c
On a side note, I believe I read somewhere that the keymap fd from wayland compositor is not guaranteed to be NULL-terminated.
If that's the case, `xkb_keymap_new_from_buffer` would be a safer choice.