### PR TITLE
wayland: Protocol fixes

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -658,7 +658,7 @@ static void connect_to_wayland(struct imv_window *window)
   assert(window->wl_registry);
 
   wl_registry_add_listener(window->wl_registry, &registry_listener, window);
-  wl_display_dispatch(window->wl_display);
+  wl_display_roundtrip(window->wl_display);
   assert(window->wl_compositor);
   assert(window->wl_xdg);
   assert(window->wl_seat);


### PR DESCRIPTION
1. Registry globals were not adequately waited for. A display roundtrip was added to fix this.
2. Content was commited irrespective of xdg_surface configure state. Track configure state and commit only after a configure is acked.