### PR TITLE
imv: fix stdin prompt and use fputs.

### DIFF
--- a/src/imv.c
+++ b/src/imv.c
@@ -508,7 +508,7 @@ static void log_to_stderr(enum imv_log_level level, const char *text, void *data
 {
   (void)data;
   if (level >= IMV_INFO) {
-    fprintf(stderr, "%s", text);
+    fputs(text, stderr);
   }
 }
 
@@ -740,7 +740,7 @@ static void *load_paths_from_stdin(void *data)
 {
   struct imv *imv = data;
 
-  imv_log(IMV_INFO, "Reading paths from stdin...");
+  imv_log(IMV_INFO, "Reading paths from stdin...\n");
 
   char buf[PATH_MAX];
   while (fgets(buf, sizeof(buf), stdin) != NULL) {


### PR DESCRIPTION
Add newline to the prompt for reading paths from stdin.

Since string formatting isn't being used, it's possible to use fputs()
directly in the logging callback in imv.c.