### PR TITLE
imv, ipc: improve error checking for ipc creation. (CI failing because it can't find ubuntu image)

### DIFF
--- a/src/imv.c
+++ b/src/imv.c
@@ -533,7 +533,9 @@ struct imv *imv_create(void)
   imv->console = imv_console_create();
   imv_console_set_command_callback(imv->console, &command_callback, imv);
   imv->ipc = imv_ipc_create();
-  imv_ipc_set_command_callback(imv->ipc, &command_callback, imv);
+  if (imv->ipc) {
+    imv_ipc_set_command_callback(imv->ipc, &command_callback, imv);
+  }
   imv->title_text = strdup(
       "imv - [${imv_current_index}/${imv_file_count}]"
       " [${imv_width}x${imv_height}] [${imv_scale}%]"

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -92,6 +92,9 @@ struct imv_ipc *imv_ipc_create(void)
   }
 
   struct imv_ipc *ipc = calloc(1, sizeof *ipc);
+  if (ipc == NULL) {
+    return NULL;
+  }
   ipc->fd = sockfd;
 
   pthread_t thread;


### PR DESCRIPTION
Since this isn't essential functionality, it's ok to simply not provide
it. In cases where XDG_RUNTIME_DIR was empty (but not unset) or set to a
directory where the user didn't have write permissions, socket creation
would fail and lead to segmentation faults in imv, due to the return
value of imv_ipc_create() not being checked.