### PR TITLE
Add default keybinding for image rotation

### DIFF
--- a/doc/imv.1.txt
+++ b/doc/imv.1.txt
@@ -222,6 +222,9 @@ imv comes with several binds configured by default
 *-*::
 	Zoom out
 
+*Ctrl+r*::
+	Rotate clockwise by 90 degrees
+
 *c*::
 	Center image
 

--- a/files/imv_config
+++ b/files/imv_config
@@ -38,6 +38,9 @@ i = zoom 1
 <minus> = zoom -1
 o = zoom -1
 
+# Rotate Clockwise by 90 degrees
+<Ctrl+r> = rotate by 90
+
 # Other commands
 x = close
 f = fullscreen


### PR DESCRIPTION
This is the same key binding used by Eye of Gnome for a 90 degree clockwise image rotation for people coming from that image viewer.

This builds on the unreleased image rotatation and flipping feature, https://github.com/eXeC64/imv/pull/233