### PR TITLE
wayland: Fix initial black screen due to size of 0x0

### DIFF
--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -610,8 +610,11 @@ static void toplevel_configure(void *data, struct xdg_toplevel *toplevel,
   (void)toplevel;
 
   struct imv_window *window = data;
-  window->width = width;
-  window->height = height;
+
+  if (width > 0 && height > 0) {
+    window->width = width;
+    window->height = height;
+  }
   window->fullscreen = false;
 
   enum xdg_toplevel_state *state;
@@ -629,10 +632,10 @@ static void toplevel_configure(void *data, struct xdg_toplevel *toplevel,
     .type = IMV_EVENT_RESIZE,
     .data = {
       .resize = {
-        .width = width,
-        .height = height,
-        .buffer_width = width * window->scale,
-        .buffer_height = height * window->scale
+        .width = window->width,
+        .height = window->height,
+        .buffer_width = window->width * window->scale,
+        .buffer_height = window->height * window->scale
       }
     }
   };
@@ -712,6 +715,9 @@ static void create_window(struct imv_window *window, int width, int height,
   window->egl_window = wl_egl_window_create(window->wl_surface, width, height);
   window->egl_surface = eglCreateWindowSurface(window->egl_display, config, window->egl_window, NULL);
   eglMakeCurrent(window->egl_display, window->egl_surface, window->egl_surface, window->egl_context);
+
+  window->width = width;
+  window->height = height;
 
   wl_surface_commit(window->wl_surface);
   wl_display_roundtrip(window->wl_display);


### PR DESCRIPTION
https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/master/stable/xdg-shell/xdg-shell.xml#L1037
states regarding xdg_toplevel.configure "The width and height arguments specify a hint to the window". imv
was using these dimensions even if they are 0x0, which is valid for the compositor to send. Clearly this is
a bad hint and should be ignored. This patch does that, and fixes #293.