### PR TITLE
Use exponential increments for zooming, fixes #239

### DIFF
--- a/src/viewport.c
+++ b/src/viewport.c
@@ -2,6 +2,7 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
+#include <math.h>
 
 struct imv_viewport {
   double scale;
@@ -159,8 +160,8 @@ void imv_viewport_zoom(struct imv_viewport *view, const struct imv_image *image,
   const int wc_x = view->buffer.width/2;
   const int wc_y = view->buffer.height/2;
 
-  double delta_scale = 0.04 * view->buffer.width * amount / image_width;
-  view->scale += delta_scale;
+  const double scale_factor = exp(0.04 * view->buffer.width * amount / image_width);
+  view->scale *= scale_factor;
 
   const double min_scale = 0.1;
   const double max_scale = 100;


### PR DESCRIPTION
Zooming on an exponential scale gives the user the perception of a constant zoom speed. This is because the user expects the size of the image to double with the same distance of scrolling, independently of the current zoom stage.

Note that I've only tested this on sway (wayland), aka works on my machine (TM). In addition to that, I've made sure that it still passes the cmocka tests. It would be nice if someone could check if this works as expected on X11.