### PR TITLE
fix double-free when backend libjpeg is used

### DIFF
--- a/src/backend_libjpeg.c
+++ b/src/backend_libjpeg.c
@@ -33,10 +33,7 @@ static void free_private(void *raw_private)
   if (private->fd >= 0) {
     munmap(private->data, private->len);
     close(private->fd);
-  } else {
-    free(private->data);
   }
-  private->data = NULL;
 
   free(private);
 }


### PR DESCRIPTION
There is a double-free issue in in `imv_free()` when a JPEG image is read from stdin:
```
$ imv - < ~/test.jpeg
double free or corruption (!prev)
[1]    73047 abort (core dumped)  imv - < ~/test.jpeg
```

The issue exists because the `open_memory()` function of the libjpeg backend stores a reference to `stdin_image_data` in `imv->current_source->private->data`. This heap-allocated memory is both free'd in `imv_free()` via `imv_source_free(imv->current_source);` and `free(imv->stdin_image_data);`.

This issue was fixed here by freeing this memory in `free_private()` (which gets called via `imv_source_free()`) only if the image data was actually read from a file (`private->fd >= 0`) and not via stdin.