### PR TITLE
Fix zoom speed dependence on buffer/image width

### DIFF
--- a/src/viewport.c
+++ b/src/viewport.c
@@ -160,7 +160,7 @@ void imv_viewport_zoom(struct imv_viewport *view, const struct imv_image *image,
   const int wc_x = view->buffer.width/2;
   const int wc_y = view->buffer.height/2;
 
-  const double scale_factor = exp(0.04 * view->buffer.width * amount / image_width);
+  const double scale_factor = pow(1.04, amount);
   view->scale *= scale_factor;
 
   const double min_scale = 0.1;


### PR DESCRIPTION
This fixes the zoom speed issue I mentioned in #336. The value of `1.04` was chosen to match the initial zoom speed when increments weren't exponential.