### PR TITLE
Don't stop listing files in dir when stat fail

### DIFF
--- a/src/navigator.c
+++ b/src/navigator.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <errno.h>
 
 #include "list.h"
 
@@ -87,8 +88,12 @@ int imv_navigator_add(struct imv_navigator *nav, const char *path,
         snprintf(path_buf, sizeof path_buf, "%s/%s", path, dir->d_name);
         struct stat new_path_info;
         if (stat(path_buf, &new_path_info)) {
-          result = 1;
-          break;
+          switch (errno) {
+          case ELOOP:
+          case ENOTDIR:
+          case ENOENT: continue;
+          default: result = 1; break;
+          }
         }
         int is_dir = S_ISDIR(new_path_info.st_mode);
         if (is_dir && recursive) {


### PR DESCRIPTION
Check `errno` when stat fail during traversal of a directory: doesn't stop
traversing for all stat errors

Should fix #335 