### PR TITLE
Fix `-n` with STDIN

### DIFF
--- a/src/imv.c
+++ b/src/imv.c
@@ -939,6 +939,7 @@ int imv_run(struct imv *imv)
 
   if (imv->starting_path) {
     if (imv->paths_from_stdin) {
+      int max_tries = 1000;
       bool is_number = true;
       for(int i=0; i<strlen(imv->starting_path); ++i) {
         if (!isdigit(imv->starting_path[i])) {
@@ -952,6 +953,9 @@ int imv_run(struct imv *imv)
       }
       bool cont = true;
       while (cont) {
+        if (max_tries <= 0) {
+          cont = false;
+        }
         imv_window_pump_events(imv->window, event_handler, imv);
         if (index == -1) {
           ssize_t img_index = imv_navigator_find_path(imv->navigator, imv->starting_path);
@@ -965,6 +969,7 @@ int imv_run(struct imv *imv)
             cont = false;
           }
         }
+        max_tries -= 1;
       }
     } else {
       ssize_t index = imv_navigator_find_path(imv->navigator, imv->starting_path);


### PR DESCRIPTION
Poll paths from STDIN when piping paths to `imv -n` until the `-n` condition is met.

There's a hardcoded value for the maximum number of retries to avoid an infinite loop when giving a number too high or giving a path that doesn't exist (in the path list).

Should fix #317 