### PR TITLE
Scale fonts when Wayland updates scaling factor

### DIFF
--- a/src/canvas.c
+++ b/src/canvas.c
@@ -69,7 +69,7 @@ void imv_canvas_free(struct imv_canvas *canvas)
   free(canvas);
 }
 
-void imv_canvas_resize(struct imv_canvas *canvas, int width, int height)
+void imv_canvas_resize(struct imv_canvas *canvas, int width, int height, double scale)
 {
   cairo_destroy(canvas->cairo);
   cairo_surface_destroy(canvas->surface);
@@ -80,6 +80,7 @@ void imv_canvas_resize(struct imv_canvas *canvas, int width, int height)
   canvas->surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32,
                                                canvas->width, canvas->height);
   assert(canvas->surface);
+  cairo_surface_set_device_scale(canvas->surface, scale, scale);
   canvas->cairo = cairo_create(canvas->surface);
   assert(canvas->cairo);
 }

--- a/src/canvas.c
+++ b/src/canvas.c
@@ -127,7 +127,7 @@ void imv_canvas_font(struct imv_canvas *canvas, const char *name, int size)
 {
   pango_font_description_set_family(canvas->font, name);
   pango_font_description_set_weight(canvas->font, PANGO_WEIGHT_NORMAL);
-  pango_font_description_set_absolute_size(canvas->font, size * PANGO_SCALE);
+  pango_font_description_set_size(canvas->font, size * PANGO_SCALE);
 }
 
 int imv_canvas_printf(struct imv_canvas *canvas, int x, int y, const char *fmt, ...)

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -19,7 +19,7 @@ struct imv_canvas *imv_canvas_create(int width, int height);
 void imv_canvas_free(struct imv_canvas *canvas);
 
 /* Set the buffer size of the canvas */
-void imv_canvas_resize(struct imv_canvas *canvas, int width, int height);
+void imv_canvas_resize(struct imv_canvas *canvas, int width, int height, double scale);
 
 /* Blank the canvas to be empty and transparent */
 void imv_canvas_clear(struct imv_canvas *canvas);

--- a/src/imv.c
+++ b/src/imv.c
@@ -447,8 +447,9 @@ static void event_handler(void *data, const struct imv_event *e)
         const int wh = e->data.resize.height;
         const int bw = e->data.resize.buffer_width;
         const int bh = e->data.resize.buffer_height;
+        const double scale = e->data.resize.scale;
         imv_viewport_update(imv->view, ww, wh, bw, bh, imv->current_image, imv->scaling_mode);
-        imv_canvas_resize(imv->canvas, bw, bh);
+        imv_canvas_resize(imv->canvas, bw, bh, scale);
         break;
       }
     case IMV_EVENT_KEYBOARD:

--- a/src/window.h
+++ b/src/window.h
@@ -24,6 +24,7 @@ struct imv_event {
       int height;
       int buffer_width;
       int buffer_height;
+      double scale;
     } resize;
     struct {
       int scancode;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -558,7 +558,8 @@ static void update_scale(struct imv_window *window)
           .width = window->width,
           .height = window->height,
           .buffer_width = buffer_width,
-          .buffer_height = buffer_height
+          .buffer_height = buffer_height,
+          .scale = window->scale,
         }
       }
     };
@@ -639,6 +640,7 @@ static void toplevel_configure(void *data, struct xdg_toplevel *toplevel,
         .height = window->height,
         .buffer_width = buffer_width,
         .buffer_height = buffer_height,
+        .scale = window->scale,
       }
     }
   };

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -346,7 +346,8 @@ void imv_window_pump_events(struct imv_window *window, imv_event_handler handler
             .width = wa.width,
             .height = wa.height,
             .buffer_width = wa.width,
-            .buffer_height = wa.height
+            .buffer_height = wa.height,
+            .scale = 1,
           }
         }
       };


### PR DESCRIPTION
This fixes #319.

The changes I made are quite small and follow the existing code practice. The new code seems to work flawlessly on my Wayland (haven't tested in a multi-screen setup): now all the interface fonts are in the right places and have the right size.

But please review it nevertheless, this is my first time working with Cairo and Wayland!

See the commit message for details.