### PR TITLE
Allow multiline strings in overlay text

### DIFF
--- a/src/canvas.c
+++ b/src/canvas.c
@@ -130,6 +130,22 @@ void imv_canvas_font(struct imv_canvas *canvas, const char *name, int size)
   pango_font_description_set_size(canvas->font, size * PANGO_SCALE);
 }
 
+PangoLayout *imv_canvas_make_layout(struct imv_canvas *canvas, const char *line)
+{
+  PangoLayout *layout = pango_cairo_create_layout(canvas->cairo);
+  pango_layout_set_font_description(layout, canvas->font);
+  pango_layout_set_text(layout, line, -1);
+
+  return layout;
+}
+
+void imv_canvas_show_layout(struct imv_canvas *canvas, int x, int y,
+                            PangoLayout *layout)
+{
+  cairo_move_to(canvas->cairo, x, y);
+  pango_cairo_show_layout(canvas->cairo, layout);
+}
+
 int imv_canvas_printf(struct imv_canvas *canvas, int x, int y, const char *fmt, ...)
 {
   char line[1024];
@@ -137,12 +153,9 @@ int imv_canvas_printf(struct imv_canvas *canvas, int x, int y, const char *fmt, 
   va_start(args, fmt);
   vsnprintf(line, sizeof line, fmt, args);
 
-  PangoLayout *layout = pango_cairo_create_layout(canvas->cairo);
-  pango_layout_set_font_description(layout, canvas->font);
-  pango_layout_set_text(layout, line, -1);
+  PangoLayout *layout = imv_canvas_make_layout(canvas, line);
 
-  cairo_move_to(canvas->cairo, x, y);
-  pango_cairo_show_layout(canvas->cairo, layout);
+  imv_canvas_show_layout(canvas, x, y, layout);
 
   PangoRectangle extents;
   pango_layout_get_pixel_extents(layout, NULL, &extents);

--- a/src/canvas.h
+++ b/src/canvas.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 
+#include <pango/pangocairo.h>
+
 struct imv_canvas;
 struct imv_image;
 
@@ -38,6 +40,15 @@ void imv_canvas_fill_checkers(struct imv_canvas *canvas, int size);
 
 /* Select the font to draw text with */
 void imv_canvas_font(struct imv_canvas *canvas, const char *name, int size);
+
+/* Prepare layout containing the given string, ready for rendering on the given
+ * canvas. The caller is responsible for releasing it with a call to
+ * g_object_unref */
+PangoLayout *imv_canvas_make_layout(struct imv_canvas *canvas, const char *str);
+
+/* Shows layout with at the specified coordinates */
+void imv_canvas_show_layout(struct imv_canvas *canvas, int x, int y,
+                            PangoLayout *layout);
 
 /* Draw some text on the canvas, returns the width used in pixels */
 int imv_canvas_printf(struct imv_canvas *canvas, int x, int y, const char *fmt, ...);

--- a/src/imv.c
+++ b/src/imv.c
@@ -1309,27 +1309,35 @@ static void render_window(struct imv *imv)
 
   /* if the overlay needs to be drawn, draw that too */
   if (imv->overlay.enabled) {
-    const int height = imv->overlay.font.size * 1.2;
-    imv_canvas_color(imv->canvas,
-        imv->overlay.background_color.r / 255.f,
-        imv->overlay.background_color.g / 255.f,
-        imv->overlay.background_color.b / 255.f,
-        imv->overlay.background_alpha / 255.f);
-    int y = 0 ;
+    char overlay_text[1024];
+    generate_env_text(imv, overlay_text, sizeof overlay_text, imv->overlay.text);
+    PangoLayout *layout = imv_canvas_make_layout(imv->canvas, overlay_text);
+
+    int width, height;
+    pango_layout_get_pixel_size(layout, &width, &height);
+
+    int y = 0;
     const int bottom_offset = 5;
     if (imv->overlay.position_at_bottom)
     {
       y = wh - height - bottom_offset;
     }
-    imv_canvas_fill_rectangle(imv->canvas, 0, y, ww, height + bottom_offset);
+
+    imv_canvas_color(imv->canvas,
+        imv->overlay.background_color.r / 255.f,
+        imv->overlay.background_color.g / 255.f,
+        imv->overlay.background_color.b / 255.f,
+        imv->overlay.background_alpha / 255.f);
+    imv_canvas_fill_rectangle(imv->canvas, 0, y, width, height + bottom_offset);
+
     imv_canvas_color(imv->canvas,
         imv->overlay.text_color.r / 255.f,
         imv->overlay.text_color.g / 255.f,
         imv->overlay.text_color.b / 255.f,
         imv->overlay.text_alpha / 255.f);
-    char overlay_text[1024];
-    generate_env_text(imv, overlay_text, sizeof overlay_text, imv->overlay.text);
-    imv_canvas_printf(imv->canvas, 0, y, "%s", overlay_text);
+    imv_canvas_show_layout(imv->canvas, 0, y, layout);
+
+    g_object_unref(layout);
   }
 
   /* draw command entry bar if needed */

--- a/src/imv.c
+++ b/src/imv.c
@@ -1945,6 +1945,7 @@ static size_t generate_env_text(struct imv *imv, char *buf, size_t buf_len, cons
 
   size_t len = 0;
   wordexp_t word;
+  setenv("IFS", "", 1);
   if (wordexp(format, &word, 0) == 0) {
     for (size_t i = 0; i < word.we_wordc; ++i) {
       len += snprintf(buf + len, buf_len - len, "%s ", word.we_wordv[i]);
@@ -1953,6 +1954,7 @@ static size_t generate_env_text(struct imv *imv, char *buf, size_t buf_len, cons
   } else {
     len += snprintf(buf, buf_len, "error expanding text");
   }
+  unsetenv("IFS");
 
   return len;
 }


### PR DESCRIPTION
| ![image](https://user-images.githubusercontent.com/7102119/131044298-d5915bc6-5130-478e-8729-02704ab037c1.png) |
| -- |
| Imv with `overlay_text = $(echo -e 'hello\nworld!')` set |

This PR partially addresses #325. It allows overlay text to have newlines, but doesn't draw the gray background rectangle properly yet.

See commit message for details.

I will later fix the rectangle and add more commits here. This PR is still WIP, let me know what you think.

Ivan