### PR TITLE
cairo: Replace <cairo/cairo.h> by <cairo.h>

### DIFF
--- a/src/canvas.c
+++ b/src/canvas.c
@@ -5,7 +5,7 @@
 
 #include <GL/gl.h>
 #include <assert.h>
-#include <cairo/cairo.h>
+#include <cairo.h>
 #include <pango/pangocairo.h>
 #include <stdarg.h>
 #include <stdbool.h>


### PR DESCRIPTION
The correct header to include is `cairo.h`, not `cairo/cairo.h`.
See https://gitlab.freedesktop.org/cairo/cairo/-/blob/master/doc/tutorial/src/include/cairo-tutorial.h.
That being said, this issue is quite common, see https://github.com/swaywm/sway/pull/6262.
Thank you.